### PR TITLE
[Fix] Missing typo

### DIFF
--- a/script/CreateRewardReceiver.s.sol
+++ b/script/CreateRewardReceiver.s.sol
@@ -11,14 +11,14 @@ contract DeployScript is Script {
     IStakePad public stakePad = IStakePad(0x4265b719f9f92508440dBC144a237e31Bb115EF0);
     address public client = 0x2918f73136Cf6bD284D51B847e680c28319eD3c3; // dev account 1
     address public provider = 0xDeA40BE986dE36CDb271e34ae04036AAE9fA5639; // dev account 2
-    uint96 public comission = 1000;
+    uint96 public commission = 1000;
 
     function setUp() public {}
 
     function run() public {
         uint256 deployerPk = vm.envUint("DEPLOYER_PK");
         vm.startBroadcast(deployerPk);
-        stakePad.deployNewRewardReceiver(client, provider, comission);
+        stakePad.deployNewRewardReceiver(client, provider, commission);
         vm.stopBroadcast();
     }
 

--- a/src/RewardReceiver.sol
+++ b/src/RewardReceiver.sol
@@ -17,14 +17,14 @@ contract RewardReceiver is IRewardReceiver, Initializable, OwnableUpgradeable, R
     uint256 public constant INIT_WITHDRAWAL_THRESHOLD =
         0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff; // max(type(uint256))
 
-    uint96 public pendingComission;
+    uint96 public pendingCommission;
     uint256 public pendingWithdrawalThreshold;
     bytes[] public validators;
 
     address internal _client;
     address internal _provider; // managed by stakepad NO MALICIOUS PROVIDER
     address internal _stakePad; // managed by stakepad NO MALICIOUS PROVIDER
-    uint96 internal _comission;
+    uint96 internal _commission;
     uint256 internal _withdrawalThreshold;
 
     modifier onlyOwnerClientOrProvider() {
@@ -56,7 +56,7 @@ contract RewardReceiver is IRewardReceiver, Initializable, OwnableUpgradeable, R
     }
 
     modifier notPendingState() {
-        require(pendingComission == 0 && pendingWithdrawalThreshold == 0, "RewardReceiver: pending state");
+        require(pendingCommission == 0 && pendingWithdrawalThreshold == 0, "RewardReceiver: pending state");
         _;
     }
 
@@ -67,7 +67,7 @@ contract RewardReceiver is IRewardReceiver, Initializable, OwnableUpgradeable, R
      */
     receive() external payable {}
 
-    function initialize(address newClient, address newProvider, uint96 newComission, address newStakePad)
+    function initialize(address newClient, address newProvider, uint96 newCommission, address newStakePad)
         external
         initializer
     {
@@ -76,37 +76,37 @@ contract RewardReceiver is IRewardReceiver, Initializable, OwnableUpgradeable, R
         __Ownable_init(msg.sender);
         __ReentrancyGuard_init();
         __stakePad_init(newStakePad);
-        __initializeRewardReceiver(newComission);
+        __initializeRewardReceiver(newCommission);
     }
 
     /**
-     * @notice Withdraws the rewards to the client and the comission to the provider
+     * @notice Withdraws the rewards to the client and the commission to the provider
      */
     function withdraw() external onlyOwnerClientOrProvider notPendingState nonReentrant {
         uint256 balance = address(this).balance;
-        uint256 weightedComission;
+        uint256 weightedCommission;
         uint256 rewards;
         if (balance > _withdrawalThreshold) {
-            weightedComission = ((balance - _withdrawalThreshold) * _comission) / BASIS_PTS;
+            weightedCommission = ((balance - _withdrawalThreshold) * _commission) / BASIS_PTS;
         } else {
-            weightedComission = (balance * _comission) / BASIS_PTS;
+            weightedCommission = (balance * _commission) / BASIS_PTS;
         }
-        require(weightedComission > 0, "RewardReceiver: comission too low");
-        rewards = balance - weightedComission;
+        require(weightedCommission > 0, "RewardReceiver: commission too low");
+        rewards = balance - weightedCommission;
 
         // transfer to provider first for safety
-        (bool success1,) = address(_provider).call{value: weightedComission}("");
+        (bool success1,) = address(_provider).call{value: weightedCommission}("");
         (bool success0,) = address(_client).call{value: rewards}("");
 
         emit RewardSent(_client, rewards);
-        emit ComissionSent(_provider, weightedComission);
+        emit CommissionSent(_provider, weightedCommission);
 
         require(success0 && success1, "RewardReceiver: transfer failed");
     }
 
-    function proposeNewComission(uint96 newComission) external onlyOwnerOrProvider {
-        _checkValidPercentange(newComission);
-        pendingComission = newComission;
+    function proposeNewCommission(uint96 newCommission) external onlyOwnerOrProvider {
+        _checkValidPercentange(newCommission);
+        pendingCommission = newCommission;
     }
 
     function proposeNewWithdrawalThreshold(uint256 newWithdrawalThreshold) external onlyOwnerOrProvider {
@@ -114,10 +114,10 @@ contract RewardReceiver is IRewardReceiver, Initializable, OwnableUpgradeable, R
         pendingWithdrawalThreshold = newWithdrawalThreshold;
     }
 
-    function acceptNewComission() external onlyClient {
-        _checkValidPercentange(pendingComission);
-        _comission = pendingComission;
-        pendingComission = 0;
+    function acceptNewCommission() external onlyClient {
+        _checkValidPercentange(pendingCommission);
+        _commission = pendingCommission;
+        pendingCommission = 0;
     }
 
     function acceptNewWithdrawalThreshold() external onlyClient {
@@ -126,9 +126,9 @@ contract RewardReceiver is IRewardReceiver, Initializable, OwnableUpgradeable, R
         pendingWithdrawalThreshold = 0;
     }
 
-    function cancelNewComission() external onlyOwnerOrProvider {
-        _checkValidPercentange(pendingComission);
-        pendingComission = 0;
+    function cancelNewCommission() external onlyOwnerOrProvider {
+        _checkValidPercentange(pendingCommission);
+        pendingCommission = 0;
     }
 
     function cancelNewWithdrawalThreshold() external onlyOwnerOrProvider {
@@ -136,8 +136,8 @@ contract RewardReceiver is IRewardReceiver, Initializable, OwnableUpgradeable, R
         pendingWithdrawalThreshold = 0;
     }
 
-    function comission() external view returns (uint96) {
-        return _comission;
+    function commission() external view returns (uint96) {
+        return _commission;
     }
 
     function withdrawalThreshold() external view returns (uint256) {
@@ -209,9 +209,9 @@ contract RewardReceiver is IRewardReceiver, Initializable, OwnableUpgradeable, R
         _stakePad = newStakePad;
     }
 
-    function __initializeRewardReceiver(uint96 newComission) internal {
-        _checkValidPercentange(newComission);
-        _comission = newComission;
+    function __initializeRewardReceiver(uint96 newCommission) internal {
+        _checkValidPercentange(newCommission);
+        _commission = newCommission;
         _withdrawalThreshold = INIT_WITHDRAWAL_THRESHOLD;
     }
 

--- a/src/StakePadV1.sol
+++ b/src/StakePadV1.sol
@@ -59,14 +59,14 @@ contract StakePadV1 is IStakePad, Initializable, UUPSUpgradeable, OwnableUpgrade
      * @notice creates a contract that will receive the rewards
      * @param client Beneficiary of the rewards
      * @param provider Account on behalf of this contract
-     * @param comission percentage of the rewards that will be sent to the provider
+     * @param commission percentage of the rewards that will be sent to the provider
      */
-    function deployNewRewardReceiver(address client, address provider, uint96 comission) external override {
+    function deployNewRewardReceiver(address client, address provider, uint96 commission) external override {
         address newRewardReceiver = Clones.clone(rewardReceiverImpl());
-        IRewardReceiver(newRewardReceiver).initialize(client, provider, comission, address(this));
+        IRewardReceiver(newRewardReceiver).initialize(client, provider, commission, address(this));
         IRewardReceiver(newRewardReceiver).transferOwnership(owner());
         _rewardReceivers.add(newRewardReceiver);
-        emit NewRewardReceiver(_rewardReceivers.length(), newRewardReceiver, client, provider, comission);
+        emit NewRewardReceiver(_rewardReceivers.length(), newRewardReceiver, client, provider, commission);
     }
 
     /**

--- a/src/interfaces/IRewardReceiver.sol
+++ b/src/interfaces/IRewardReceiver.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.22;
 
 interface IRewardReceiver {
     event RewardSent(address indexed, uint256);
-    event ComissionSent(address indexed, uint256);
+    event CommissionSent(address indexed, uint256);
 
     function initialize(address, address, uint96, address) external;
 
@@ -16,15 +16,15 @@ interface IRewardReceiver {
 
     function withdraw() external;
 
-    function proposeNewComission(uint96) external;
+    function proposeNewCommission(uint96) external;
 
     function proposeNewWithdrawalThreshold(uint256) external;
 
-    function cancelNewComission() external;
+    function cancelNewCommission() external;
 
     function cancelNewWithdrawalThreshold() external;
 
-    function acceptNewComission() external;
+    function acceptNewCommission() external;
 
     function acceptNewWithdrawalThreshold() external;
 }

--- a/src/interfaces/IStakePad.sol
+++ b/src/interfaces/IStakePad.sol
@@ -5,7 +5,7 @@ import "../utils/StakePadUtils.sol";
 
 interface IStakePad {
     event NewRewardReceiver(
-        uint256 indexed index, address rewardReceiver, address client, address provider, uint96 comission
+        uint256 indexed index, address rewardReceiver, address client, address provider, uint96 commission
     );
 
     function fundValidators(StakePadUtils.BeaconDepositParams[] memory) external payable;

--- a/src/test/TestStakePadV1.sol
+++ b/src/test/TestStakePadV1.sol
@@ -33,12 +33,12 @@ contract TestStakePadV1 is IStakePad, Initializable, UUPSUpgradeable, OwnableUpg
         __Ownable_init(msg.sender);
     }
 
-    function deployNewRewardReceiver(address client, address provider, uint96 comission) external override {
+    function deployNewRewardReceiver(address client, address provider, uint96 commission) external override {
         address newRewardReceiver = Clones.clone(rewardReceiverImpl());
-        IRewardReceiver(newRewardReceiver).initialize(client, provider, comission, address(this));
+        IRewardReceiver(newRewardReceiver).initialize(client, provider, commission, address(this));
         IRewardReceiver(newRewardReceiver).transferOwnership(owner());
         _rewardReceivers.add(newRewardReceiver);
-        emit NewRewardReceiver(_rewardReceivers.length(), newRewardReceiver, client, provider, comission);
+        emit NewRewardReceiver(_rewardReceivers.length(), newRewardReceiver, client, provider, commission);
     }
 
     /**

--- a/src/test/TestStakePadV2.sol
+++ b/src/test/TestStakePadV2.sol
@@ -45,14 +45,14 @@ contract TestStakePadV2 is IStakePad, Initializable, UUPSUpgradeable, OwnableUpg
      * @notice creates a contract that will receive the rewards
      * @param client Beneficiary of the rewards
      * @param provider Account on behalf of this contract
-     * @param comission percentage of the rewards that will be sent to the provider
+     * @param commission percentage of the rewards that will be sent to the provider
      */
-    function deployNewRewardReceiver(address client, address provider, uint96 comission) external override onlyOwner {
+    function deployNewRewardReceiver(address client, address provider, uint96 commission) external override onlyOwner {
         address newRewardReceiver = Clones.clone(rewardReceiverImpl());
-        IRewardReceiver(newRewardReceiver).initialize(client, provider, comission, address(this));
+        IRewardReceiver(newRewardReceiver).initialize(client, provider, commission, address(this));
         IRewardReceiver(newRewardReceiver).transferOwnership(owner());
         _rewardReceivers.add(newRewardReceiver);
-        emit NewRewardReceiver(_rewardReceivers.length(), newRewardReceiver, client, provider, comission);
+        emit NewRewardReceiver(_rewardReceivers.length(), newRewardReceiver, client, provider, commission);
     }
 
     function setNewVariable(uint256 variable) external onlyOwner {

--- a/test/RewardReceiver.t.sol
+++ b/test/RewardReceiver.t.sol
@@ -26,7 +26,7 @@ contract RewardReceiverTest is TestUtils {
         // perform operations from owner
         vm.startPrank(owner);
         rewardReceiver = new RewardReceiver();
-        rewardReceiver.initialize(client, provider, comission, testStakePad);
+        rewardReceiver.initialize(client, provider, commission, testStakePad);
         vm.stopPrank();
     }
 
@@ -37,8 +37,8 @@ contract RewardReceiverTest is TestUtils {
             "provider not set correctly"
         );
         require(
-            rewardReceiver.comission() == comission,
-            "comission not set correctly"
+            rewardReceiver.commission() == commission,
+            "commission not set correctly"
         );
     }
 
@@ -70,7 +70,7 @@ contract RewardReceiverTest is TestUtils {
     function testCannotInitializeTwice() public {
         vm.startPrank(owner);
         vm.expectRevert(abi.encodeWithSelector(0xf92ee8a9));
-        rewardReceiver.initialize(client, provider, comission, testStakePad);
+        rewardReceiver.initialize(client, provider, commission, testStakePad);
         vm.stopPrank();
     }
 
@@ -82,14 +82,14 @@ contract RewardReceiverTest is TestUtils {
         testRewardReceiver.initialize(
             address(0),
             provider,
-            comission,
+            commission,
             testStakePad
         );
         vm.expectRevert("RewardReceiver: provider is the zero address");
         testRewardReceiver.initialize(
             client,
             address(0),
-            comission,
+            commission,
             testStakePad
         );
         vm.expectRevert("RewardReceiver: invalid percentage");
@@ -97,60 +97,60 @@ contract RewardReceiverTest is TestUtils {
         vm.expectRevert("RewardReceiver: invalid percentage");
         testRewardReceiver.initialize(client, provider, 0, testStakePad);
         vm.expectRevert("RewardReceiver: stakePad is the zero address");
-        testRewardReceiver.initialize(client, provider, comission, address(0));
+        testRewardReceiver.initialize(client, provider, commission, address(0));
 
         // passing correct params should work
         testRewardReceiver.initialize(
             client,
             provider,
-            comission,
+            commission,
             testStakePad
         );
     }
 
-    function testMigrateComission() public {
-        // fails to propose a newComission when not the owner or provider
+    function testMigrateCommission() public {
+        // fails to propose a newCommission when not the owner or provider
         vm.prank(client);
         vm.expectRevert("RewardReceiver: caller is not the owner or provider");
-        rewardReceiver.proposeNewComission(comission * 2);
+        rewardReceiver.proposeNewCommission(commission * 2);
 
-        // fails to propose a newComission when new comission is 0
+        // fails to propose a newCommission when new commission is 0
         vm.prank(owner);
         vm.expectRevert("RewardReceiver: invalid percentage");
-        rewardReceiver.proposeNewComission(0);
+        rewardReceiver.proposeNewCommission(0);
 
-        // fails to propose a newComission when new comission more than 100%
+        // fails to propose a newCommission when new commission more than 100%
         vm.prank(owner);
         vm.expectRevert("RewardReceiver: invalid percentage");
-        rewardReceiver.proposeNewComission(10001);
+        rewardReceiver.proposeNewCommission(10001);
 
-        // faiils to accept a comission when the comission is 0
+        // faiils to accept a commission when the commission is 0
         vm.prank(client);
         vm.expectRevert("RewardReceiver: invalid percentage");
-        rewardReceiver.acceptNewComission();
+        rewardReceiver.acceptNewCommission();
 
-        // accepts a new incoming comission
+        // accepts a new incoming commission
         uint256 ss = vm.snapshot();
         vm.prank(owner);
-        rewardReceiver.proposeNewComission(comission * 2);
+        rewardReceiver.proposeNewCommission(commission * 2);
         vm.prank(client);
-        rewardReceiver.acceptNewComission();
+        rewardReceiver.acceptNewCommission();
 
         require(
-            rewardReceiver.comission() == comission * 2,
-            "comission not updated correctly"
+            rewardReceiver.commission() == commission * 2,
+            "commission not updated correctly"
         );
 
-        // allows provider to also propose new comission
+        // allows provider to also propose new commission
         vm.revertTo(ss);
         vm.prank(provider);
-        rewardReceiver.proposeNewComission(comission * 2);
+        rewardReceiver.proposeNewCommission(commission * 2);
         vm.prank(client);
-        rewardReceiver.acceptNewComission();
+        rewardReceiver.acceptNewCommission();
 
         require(
-            rewardReceiver.comission() == comission * 2,
-            "comission not updated correctly"
+            rewardReceiver.commission() == commission * 2,
+            "commission not updated correctly"
         );
     }
 
@@ -209,7 +209,7 @@ contract RewardReceiverTest is TestUtils {
         newRewardReceiver.initialize(
             address(sampleAttackContract),
             provider,
-            comission,
+            commission,
             testStakePad
         );
         vm.prank(owner);
@@ -261,7 +261,7 @@ contract RewardReceiverTest is TestUtils {
 
         // fails to withdraw when balance is too low
         vm.prank(owner);
-        vm.expectRevert("RewardReceiver: comission too low");
+        vm.expectRevert("RewardReceiver: commission too low");
         rewardReceiver.withdraw();
 
         // fails if the transfer function fails
@@ -271,7 +271,7 @@ contract RewardReceiverTest is TestUtils {
         testRewardReceiver.initialize(
             address(sampleContractWithdrawer),
             provider,
-            comission,
+            commission,
             testStakePad
         );
         vm.deal(address(testRewardReceiver), TEST_WITHDRAWAL_THRESHOLD * 2);
@@ -286,7 +286,7 @@ contract RewardReceiverTest is TestUtils {
         testRewardReceiver.initialize(
             address(sampleContractWithdrawerReceive),
             provider,
-            comission,
+            commission,
             testStakePad
         );
         vm.deal(address(testRewardReceiver), TEST_WITHDRAWAL_THRESHOLD * 2);
@@ -313,7 +313,7 @@ contract RewardReceiverTest is TestUtils {
         // ----PERFORM CHECKS----
         require(
             providerBalanceBefore +
-                (rewardReceiverBalanceBefore * rewardReceiver.comission()) /
+                (rewardReceiverBalanceBefore * rewardReceiver.commission()) /
                 BASIS_PTS ==
                 providerBalanceAfter,
             "withdrawn amount not correct"
@@ -322,7 +322,7 @@ contract RewardReceiverTest is TestUtils {
         require(
             clientBalanceBefore +
                 rewardReceiverBalanceBefore -
-                (rewardReceiverBalanceBefore * rewardReceiver.comission()) /
+                (rewardReceiverBalanceBefore * rewardReceiver.commission()) /
                 BASIS_PTS ==
                 clientBalanceAfter,
             "withdrawn amount not correct"
@@ -338,7 +338,7 @@ contract RewardReceiverTest is TestUtils {
 
         // ----PERFORM CALL--- FAILS
         vm.prank(owner);
-        vm.expectRevert("RewardReceiver: comission too low");
+        vm.expectRevert("RewardReceiver: commission too low");
         rewardReceiver.withdraw();
 
         // CHECK AMOUNTS transferred
@@ -369,7 +369,7 @@ contract RewardReceiverTest is TestUtils {
         require(
             providerBalanceBefore +
                 ((rewardReceiverBalanceBefore - TEST_WITHDRAWAL_THRESHOLD) *
-                    rewardReceiver.comission()) /
+                    rewardReceiver.commission()) /
                 BASIS_PTS ==
                 providerBalanceAfter,
             "withdrawn amount not correct"
@@ -379,7 +379,7 @@ contract RewardReceiverTest is TestUtils {
             clientBalanceBefore +
                 (rewardReceiverBalanceBefore) -
                 ((rewardReceiverBalanceBefore - TEST_WITHDRAWAL_THRESHOLD) *
-                    rewardReceiver.comission()) /
+                    rewardReceiver.commission()) /
                 BASIS_PTS ==
                 clientBalanceAfter,
             "withdrawn amount not correct"
@@ -389,7 +389,7 @@ contract RewardReceiverTest is TestUtils {
     function testCannotWithdrawWhenPending() public {
         vm.deal(address(rewardReceiver), 16 ether);
         vm.prank(owner);
-        rewardReceiver.proposeNewComission(comission * 2);
+        rewardReceiver.proposeNewCommission(commission * 2);
         vm.prank(client);
         vm.expectRevert("RewardReceiver: pending state");
         rewardReceiver.withdraw();
@@ -403,14 +403,14 @@ contract RewardReceiverTest is TestUtils {
         rewardReceiver.withdraw();
     }
 
-    function testCancelPendingComissionAndWithdrawalThreshold() public {
-        require(rewardReceiver.pendingComission() == 0);
+    function testCancelPendingCommissionAndWithdrawalThreshold() public {
+        require(rewardReceiver.pendingCommission() == 0);
         vm.prank(owner);
-        rewardReceiver.proposeNewComission(comission * 2);
-        require(rewardReceiver.pendingComission() == comission * 2);
+        rewardReceiver.proposeNewCommission(commission * 2);
+        require(rewardReceiver.pendingCommission() == commission * 2);
         vm.prank(provider);
-        rewardReceiver.cancelNewComission();
-        require(rewardReceiver.pendingComission() == 0);
+        rewardReceiver.cancelNewCommission();
+        require(rewardReceiver.pendingCommission() == 0);
 
         require(rewardReceiver.pendingWithdrawalThreshold() == 0);
         vm.prank(owner);
@@ -426,7 +426,7 @@ contract RewardReceiverTest is TestUtils {
     }
 
     function testFuzzWithdrawal(uint256 balanceOfContract) public {
-        vm.assume(balanceOfContract < MAX_UINT / rewardReceiver.comission());
+        vm.assume(balanceOfContract < MAX_UINT / rewardReceiver.commission());
         // CHECK AMOUNTS transferred
         vm.deal(address(rewardReceiver), balanceOfContract);
 
@@ -443,23 +443,23 @@ contract RewardReceiverTest is TestUtils {
         uint256 clientBalanceBefore = address(client).balance;
 
         // CALCUATE EXPECTED AMOUNTS
-        uint256 comission;
+        uint256 commission;
 
         if (balanceOfContract > TEST_WITHDRAWAL_THRESHOLD) {
-            comission =
+            commission =
                 ((balanceOfContract - TEST_WITHDRAWAL_THRESHOLD) *
-                    rewardReceiver.comission()) /
+                    rewardReceiver.commission()) /
                 BASIS_PTS;
         } else {
-            comission =
-                (balanceOfContract * rewardReceiver.comission()) /
+            commission =
+                (balanceOfContract * rewardReceiver.commission()) /
                 BASIS_PTS;
         }
 
         // ----PERFORM CALL WITH CONDITIONAL REVERT---
         vm.prank(owner);
-        if (comission == 0) {
-            vm.expectRevert("RewardReceiver: comission too low");
+        if (commission == 0) {
+            vm.expectRevert("RewardReceiver: commission too low");
             rewardReceiver.withdraw();
         } else {
             rewardReceiver.withdraw();
@@ -471,7 +471,7 @@ contract RewardReceiverTest is TestUtils {
 
             // ----PERFORM CHECKS----
             require(
-                providerBalanceBefore + comission == providerBalanceAfter,
+                providerBalanceBefore + commission == providerBalanceAfter,
                 "withdrawn amount not correct"
             );
             require(
@@ -479,7 +479,7 @@ contract RewardReceiverTest is TestUtils {
                 "rewardReceiver not empty"
             );
             require(
-                clientBalanceBefore + balanceOfContract - comission ==
+                clientBalanceBefore + balanceOfContract - commission ==
                     clientBalanceAfter,
                 "withdrawn amount not correct"
             );
@@ -579,14 +579,14 @@ contract RewardReceiverTest is TestUtils {
         );
     }
 
-    function testFuzzMigrateComissionOrThreshold(
-        uint96 newInputComission,
+    function testFuzzMigrateCommissionOrThreshold(
+        uint96 newInputCommission,
         uint96 newInputThreshold
     ) public {
-        if (newInputComission > BASIS_PTS || newInputComission == 0) {
+        if (newInputCommission > BASIS_PTS || newInputCommission == 0) {
             vm.prank(owner);
             vm.expectRevert("RewardReceiver: invalid percentage");
-            rewardReceiver.proposeNewComission(newInputComission);
+            rewardReceiver.proposeNewCommission(newInputCommission);
         } else {
             if (newInputThreshold == 0) {
                 vm.prank(owner);
@@ -594,25 +594,25 @@ contract RewardReceiverTest is TestUtils {
                 rewardReceiver.proposeNewWithdrawalThreshold(newInputThreshold);
             } else {
                 vm.prank(owner);
-                rewardReceiver.proposeNewComission(newInputComission);
+                rewardReceiver.proposeNewCommission(newInputCommission);
                 vm.prank(owner);
                 rewardReceiver.proposeNewWithdrawalThreshold(newInputThreshold);
                 vm.prank(client);
                 rewardReceiver.acceptNewWithdrawalThreshold();
                 vm.prank(client);
-                rewardReceiver.acceptNewComission();
+                rewardReceiver.acceptNewCommission();
 
                 require(
-                    rewardReceiver.comission() == newInputComission,
-                    "comission not updated correctly"
+                    rewardReceiver.commission() == newInputCommission,
+                    "commission not updated correctly"
                 );
                 require(
                     rewardReceiver.withdrawalThreshold() == newInputThreshold,
                     "withdrawalThreshold not updated correctly"
                 );
                 require(
-                    rewardReceiver.pendingComission() == 0,
-                    "pendingComission not updated correctly"
+                    rewardReceiver.pendingCommission() == 0,
+                    "pendingCommission not updated correctly"
                 );
                 require(
                     rewardReceiver.pendingWithdrawalThreshold() == 0,

--- a/test/StakePad.t.sol
+++ b/test/StakePad.t.sol
@@ -87,10 +87,10 @@ contract StakePadTest is TestUtils {
     function testDeployRewardReceivers() public {
         address client = account1;
         address provider = account2;
-        uint96 comission = 1000;
+        uint96 commission = 1000;
         vm.prank(owner);
         vm.recordLogs();
-        stakePad.deployNewRewardReceiver(client, provider, comission);
+        stakePad.deployNewRewardReceiver(client, provider, commission);
         Vm.Log[] memory entries = vm.getRecordedLogs();
         (address newRewardReceiver,,,) =
             abi.decode(entries[entries.length - 1].data, (address, address, address, uint96));
@@ -102,7 +102,7 @@ contract StakePadTest is TestUtils {
         require(
             RewardReceiver(payable(newRewardReceiver)).provider() == provider, "Provider address is not set correctly"
         );
-        require(RewardReceiver(payable(newRewardReceiver)).comission() == comission, "Comission is not set correctly");
+        require(RewardReceiver(payable(newRewardReceiver)).commission() == commission, "Commission is not set correctly");
         require(RewardReceiver(payable(newRewardReceiver)).owner() == owner, "Owner address is not set correctly");
     }
 
@@ -128,10 +128,10 @@ contract StakePadTest is TestUtils {
 
         address client = account1;
         address provider = account2;
-        uint96 comission = 1000;
+        uint96 commission = 1000;
         vm.prank(owner);
         vm.recordLogs();
-        stakePad.deployNewRewardReceiver(client, provider, comission);
+        stakePad.deployNewRewardReceiver(client, provider, commission);
         Vm.Log[] memory entries = vm.getRecordedLogs();
         (address newRewardReceiver,,,) =
             abi.decode(entries[entries.length - 1].data, (address, address, address, uint96));

--- a/test/Utils.t.sol
+++ b/test/Utils.t.sol
@@ -22,7 +22,7 @@ contract TestUtils is Test {
     address public account3 = vm.addr(6);
     address public testStakePad = vm.addr(7);
 
-    uint96 comission = 1000; // 10% comission
+    uint96 commission = 1000; // 10% commission
 
     function _getRandomDepositParams(uint256 amount)
         internal


### PR DESCRIPTION
fix: standardize spelling of "commission" across all contracts and tests to improve code consistency and readability