### PR TITLE
Improve reward receiver bookkeeping

### DIFF
--- a/src/RewardReceiver.sol
+++ b/src/RewardReceiver.sol
@@ -30,6 +30,7 @@ contract RewardReceiver is IRewardReceiver, Initializable, OwnableUpgradeable, R
     uint96 internal _commission;
     uint256 internal _withdrawalThreshold;
     uint256 internal _feeAccountedRewards;
+    uint256[] internal _validatorPrincipals;
 
     modifier onlyOwnerClientOrProvider() {
         require(
@@ -92,7 +93,7 @@ contract RewardReceiver is IRewardReceiver, Initializable, OwnableUpgradeable, R
         uint256 availableBalance = _unallocatedBalance();
         require(availableBalance > 0, "RewardReceiver: no funds to allocate");
 
-        uint256 totalReceived = address(this).balance + totalClaimedClient + totalClaimedProvider;
+        uint256 totalReceived = _lifetimeReceived();
         uint256 totalRewards = totalReceived > _withdrawalThreshold ? totalReceived - _withdrawalThreshold : 0;
         uint256 grossRewards = totalRewards > _feeAccountedRewards ? totalRewards - _feeAccountedRewards : 0;
         uint256 weightedCommission = (grossRewards * _commission) / BASIS_PTS;
@@ -206,11 +207,12 @@ contract RewardReceiver is IRewardReceiver, Initializable, OwnableUpgradeable, R
     }
 
     function lifetimeReceived() external view returns (uint256) {
-        return address(this).balance + totalClaimedClient + totalClaimedProvider;
+        return _lifetimeReceived();
     }
 
     function _addValidator(bytes memory pubkey, uint256 protectedPrincipal) internal {
         validators.push(pubkey);
+        _validatorPrincipals.push(protectedPrincipal);
         _withdrawalThreshold += protectedPrincipal;
         emit ValidatorAdded(pubkey, protectedPrincipal, _withdrawalThreshold);
     }
@@ -219,11 +221,15 @@ contract RewardReceiver is IRewardReceiver, Initializable, OwnableUpgradeable, R
         uint256 len = validators.length;
         require(index < len, "RewardReceiver : invalid index");
         bytes memory removedValidator = validators[index];
+        uint256 removedPrincipal = _validatorPrincipals[index];
         if (index != len - 1) {
             validators[index] = validators[len - 1];
+            _validatorPrincipals[index] = _validatorPrincipals[len - 1];
         }
         validators.pop();
-        emit ValidatorRemoved(index, removedValidator);
+        _validatorPrincipals.pop();
+        _decreaseProtectedPrincipal(removedPrincipal);
+        emit ValidatorRemoved(index, removedValidator, removedPrincipal, _withdrawalThreshold);
     }
 
     function changeStakePad(address newStakePad) external onlyOwner {
@@ -238,6 +244,8 @@ contract RewardReceiver is IRewardReceiver, Initializable, OwnableUpgradeable, R
         uint256 balance = _unallocatedBalance();
         uint256 amounToWithdraw = (balance * percentage) / BASIS_PTS;
         require(amounToWithdraw > 0, "RewardReceiver: amount too low");
+        totalClaimedProvider += amounToWithdraw;
+        _feeAccountedRewards += amounToWithdraw;
         (bool success,) = address(_provider).call{value: amounToWithdraw}("");
         require(success, "RewardReceiver: transfer failed");
         emit PercentageWithdrawn(_msgSender(), _provider, percentage, amounToWithdraw);
@@ -310,6 +318,26 @@ contract RewardReceiver is IRewardReceiver, Initializable, OwnableUpgradeable, R
         require(balance >= allocatedBalance, "RewardReceiver: insufficient balance");
 
         return balance - allocatedBalance;
+    }
+
+    function _lifetimeReceived() internal view returns (uint256) {
+        return address(this).balance + totalClaimedClient + totalClaimedProvider;
+    }
+
+    function _decreaseProtectedPrincipal(uint256 protectedPrincipal) internal {
+        if (protectedPrincipal == 0) {
+            return;
+        }
+        if (protectedPrincipal >= _withdrawalThreshold) {
+            _withdrawalThreshold = 0;
+        } else {
+            _withdrawalThreshold -= protectedPrincipal;
+        }
+        uint256 received = _lifetimeReceived();
+        uint256 accountedPrincipal = received > _feeAccountedRewards ? received - _feeAccountedRewards : 0;
+        if (_withdrawalThreshold < accountedPrincipal) {
+            _withdrawalThreshold = accountedPrincipal;
+        }
     }
 
     function _checkValidPercentange(uint96 newPercentage) internal pure {

--- a/src/RewardReceiver.sol
+++ b/src/RewardReceiver.sol
@@ -14,11 +14,14 @@ import "./interfaces/IRewardReceiver.sol";
  */
 contract RewardReceiver is IRewardReceiver, Initializable, OwnableUpgradeable, ReentrancyGuardUpgradeable {
     uint96 public constant BASIS_PTS = 10000;
-    uint256 public constant INIT_WITHDRAWAL_THRESHOLD =
-        0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff; // max(type(uint256))
+    uint256 public constant INIT_WITHDRAWAL_THRESHOLD = 0;
 
     uint96 public pendingCommission;
     uint256 public pendingWithdrawalThreshold;
+    uint256 public claimableClient;
+    uint256 public claimableProvider;
+    uint256 public totalClaimedClient;
+    uint256 public totalClaimedProvider;
     bytes[] public validators;
 
     address internal _client;
@@ -26,6 +29,7 @@ contract RewardReceiver is IRewardReceiver, Initializable, OwnableUpgradeable, R
     address internal _stakePad; // managed by stakepad NO MALICIOUS PROVIDER
     uint96 internal _commission;
     uint256 internal _withdrawalThreshold;
+    uint256 internal _feeAccountedRewards;
 
     modifier onlyOwnerClientOrProvider() {
         require(
@@ -65,7 +69,9 @@ contract RewardReceiver is IRewardReceiver, Initializable, OwnableUpgradeable, R
      * @dev execution layer rewards may be sent as plain ETH transfers
      * @dev withdrawals from consensus layer to be sent through balance increments
      */
-    receive() external payable {}
+    receive() external payable {
+        emit FundsReceived(_msgSender(), msg.value, address(this).balance);
+    }
 
     function initialize(address newClient, address newProvider, uint96 newCommission, address newStakePad)
         external
@@ -80,60 +86,99 @@ contract RewardReceiver is IRewardReceiver, Initializable, OwnableUpgradeable, R
     }
 
     /**
-     * @notice Withdraws the rewards to the client and the commission to the provider
+     * @notice Allocates newly received funds to client/provider claimable balances
      */
     function withdraw() external onlyOwnerClientOrProvider notPendingState nonReentrant {
-        uint256 balance = address(this).balance;
-        uint256 weightedCommission;
-        uint256 rewards;
-        if (balance > _withdrawalThreshold) {
-            weightedCommission = ((balance - _withdrawalThreshold) * _commission) / BASIS_PTS;
-        } else {
-            weightedCommission = (balance * _commission) / BASIS_PTS;
-        }
-        require(weightedCommission > 0, "RewardReceiver: commission too low");
-        rewards = balance - weightedCommission;
+        uint256 availableBalance = _unallocatedBalance();
+        require(availableBalance > 0, "RewardReceiver: no funds to allocate");
 
-        // transfer to provider first for safety
-        (bool success1,) = address(_provider).call{value: weightedCommission}("");
-        (bool success0,) = address(_client).call{value: rewards}("");
+        uint256 totalReceived = address(this).balance + totalClaimedClient + totalClaimedProvider;
+        uint256 totalRewards = totalReceived > _withdrawalThreshold ? totalReceived - _withdrawalThreshold : 0;
+        uint256 grossRewards = totalRewards > _feeAccountedRewards ? totalRewards - _feeAccountedRewards : 0;
+        uint256 weightedCommission = (grossRewards * _commission) / BASIS_PTS;
 
-        emit RewardSent(_client, rewards);
-        emit CommissionSent(_provider, weightedCommission);
+        require(weightedCommission <= availableBalance, "RewardReceiver: invalid accounting");
 
-        require(success0 && success1, "RewardReceiver: transfer failed");
+        uint256 clientAmount = availableBalance - weightedCommission;
+        uint256 principalAmount = availableBalance > grossRewards ? availableBalance - grossRewards : 0;
+
+        claimableClient += clientAmount;
+        claimableProvider += weightedCommission;
+        _feeAccountedRewards = totalRewards;
+
+        emit WithdrawalAllocated(
+            _client, _provider, principalAmount, grossRewards, weightedCommission, clientAmount, weightedCommission
+        );
+    }
+
+    function claimClient() external {
+        claimClient(payable(_client));
+    }
+
+    function claimClient(address payable recipient) public onlyClient nonReentrant {
+        require(recipient != address(0), "RewardReceiver: recipient is the zero address");
+
+        uint256 amount = claimableClient;
+        require(amount > 0, "RewardReceiver: nothing to claim");
+
+        claimableClient = 0;
+        totalClaimedClient += amount;
+
+        (bool success,) = recipient.call{value: amount}("");
+        require(success, "RewardReceiver: transfer failed");
+
+        emit ClientClaimed(_client, recipient, amount);
+    }
+
+    function claimProvider() external {
+        claimProvider(payable(_provider));
+    }
+
+    function claimProvider(address payable recipient) public nonReentrant {
+        require(provider() == _msgSender(), "RewardReceiver: caller is not the provider");
+        _claimProvider(recipient);
     }
 
     function proposeNewCommission(uint96 newCommission) external onlyOwnerOrProvider {
         _checkValidPercentange(newCommission);
         pendingCommission = newCommission;
+        emit CommissionProposed(_msgSender(), newCommission);
     }
 
     function proposeNewWithdrawalThreshold(uint256 newWithdrawalThreshold) external onlyOwnerOrProvider {
         _checkValidWithdrawalThreshold(newWithdrawalThreshold);
         pendingWithdrawalThreshold = newWithdrawalThreshold;
+        emit WithdrawalThresholdProposed(_msgSender(), newWithdrawalThreshold);
     }
 
     function acceptNewCommission() external onlyClient {
         _checkValidPercentange(pendingCommission);
+        uint96 previousCommission = _commission;
         _commission = pendingCommission;
         pendingCommission = 0;
+        emit CommissionAccepted(_msgSender(), previousCommission, _commission);
     }
 
     function acceptNewWithdrawalThreshold() external onlyClient {
         _checkValidWithdrawalThreshold(pendingWithdrawalThreshold);
+        uint256 previousWithdrawalThreshold = _withdrawalThreshold;
         _withdrawalThreshold = pendingWithdrawalThreshold;
         pendingWithdrawalThreshold = 0;
+        emit WithdrawalThresholdAccepted(_msgSender(), previousWithdrawalThreshold, _withdrawalThreshold);
     }
 
     function cancelNewCommission() external onlyOwnerOrProvider {
         _checkValidPercentange(pendingCommission);
+        uint96 cancelledCommission = pendingCommission;
         pendingCommission = 0;
+        emit CommissionCancelled(_msgSender(), cancelledCommission);
     }
 
     function cancelNewWithdrawalThreshold() external onlyOwnerOrProvider {
         _checkValidWithdrawalThreshold(pendingWithdrawalThreshold);
+        uint256 cancelledWithdrawalThreshold = pendingWithdrawalThreshold;
         pendingWithdrawalThreshold = 0;
+        emit WithdrawalThresholdCancelled(_msgSender(), cancelledWithdrawalThreshold);
     }
 
     function commission() external view returns (uint96) {
@@ -145,29 +190,57 @@ contract RewardReceiver is IRewardReceiver, Initializable, OwnableUpgradeable, R
     }
 
     function addValidator(bytes memory pubkey) external onlyStakePadOrProviderOrAdmin {
+        _addValidator(pubkey, 0);
+    }
+
+    function addValidator(bytes memory pubkey, uint256 protectedPrincipal) external onlyStakePadOrProviderOrAdmin {
+        _addValidator(pubkey, protectedPrincipal);
+    }
+
+    function feeAccountedRewards() external view returns (uint256) {
+        return _feeAccountedRewards;
+    }
+
+    function unallocatedBalance() external view returns (uint256) {
+        return _unallocatedBalance();
+    }
+
+    function lifetimeReceived() external view returns (uint256) {
+        return address(this).balance + totalClaimedClient + totalClaimedProvider;
+    }
+
+    function _addValidator(bytes memory pubkey, uint256 protectedPrincipal) internal {
         validators.push(pubkey);
+        _withdrawalThreshold += protectedPrincipal;
+        emit ValidatorAdded(pubkey, protectedPrincipal, _withdrawalThreshold);
     }
 
     function removeValidator(uint256 index) external onlyStakePadOrProviderOrAdmin {
         uint256 len = validators.length;
         require(index < len, "RewardReceiver : invalid index");
+        bytes memory removedValidator = validators[index];
         if (index != len - 1) {
             validators[index] = validators[len - 1];
         }
         validators.pop();
+        emit ValidatorRemoved(index, removedValidator);
     }
 
     function changeStakePad(address newStakePad) external onlyOwner {
+        require(newStakePad != address(0), "RewardReceiver: stakePad is the zero address");
+        address previousStakePad = _stakePad;
         _stakePad = newStakePad;
+        emit StakePadChanged(previousStakePad, newStakePad);
     }
 
     function percentageWithdraw(uint96 percentage) external onlyOwner {
         _checkValidPercentange(percentage);
-        uint256 balance = address(this).balance;
+        uint256 balance = _unallocatedBalance();
         uint256 amounToWithdraw = (balance * percentage) / BASIS_PTS;
         require(amounToWithdraw > 0, "RewardReceiver: amount too low");
         (bool success,) = address(_provider).call{value: amounToWithdraw}("");
         require(success, "RewardReceiver: transfer failed");
+        emit PercentageWithdrawn(_msgSender(), _provider, percentage, amounToWithdraw);
     }
 
     function getValidators() external view returns (bytes[] memory) {
@@ -213,6 +286,30 @@ contract RewardReceiver is IRewardReceiver, Initializable, OwnableUpgradeable, R
         _checkValidPercentange(newCommission);
         _commission = newCommission;
         _withdrawalThreshold = INIT_WITHDRAWAL_THRESHOLD;
+    }
+
+    function _claimProvider(address payable recipient) internal {
+        require(recipient != address(0), "RewardReceiver: recipient is the zero address");
+
+        uint256 amount = claimableProvider;
+        require(amount > 0, "RewardReceiver: nothing to claim");
+
+        claimableProvider = 0;
+        totalClaimedProvider += amount;
+
+        (bool success,) = recipient.call{value: amount}("");
+        require(success, "RewardReceiver: transfer failed");
+
+        emit ProviderClaimed(_provider, recipient, amount);
+    }
+
+    function _unallocatedBalance() internal view returns (uint256) {
+        uint256 allocatedBalance = claimableClient + claimableProvider;
+        uint256 balance = address(this).balance;
+
+        require(balance >= allocatedBalance, "RewardReceiver: insufficient balance");
+
+        return balance - allocatedBalance;
     }
 
     function _checkValidPercentange(uint96 newPercentage) internal pure {

--- a/src/RewardReceiver.sol
+++ b/src/RewardReceiver.sol
@@ -18,10 +18,6 @@ contract RewardReceiver is IRewardReceiver, Initializable, OwnableUpgradeable, R
 
     uint96 public pendingCommission;
     uint256 public pendingWithdrawalThreshold;
-    uint256 public claimableClient;
-    uint256 public claimableProvider;
-    uint256 public totalClaimedClient;
-    uint256 public totalClaimedProvider;
     bytes[] public validators;
 
     address internal _client;
@@ -29,8 +25,13 @@ contract RewardReceiver is IRewardReceiver, Initializable, OwnableUpgradeable, R
     address internal _stakePad; // managed by stakepad NO MALICIOUS PROVIDER
     uint96 internal _commission;
     uint256 internal _withdrawalThreshold;
+    uint256 public claimableClient;
+    uint256 public claimableProvider;
+    uint256 public totalClaimedClient;
+    uint256 public totalClaimedProvider;
     uint256 internal _feeAccountedRewards;
     uint256[] internal _validatorPrincipals;
+    bool internal _hasPendingWithdrawalThreshold;
 
     modifier onlyOwnerClientOrProvider() {
         require(
@@ -47,8 +48,10 @@ contract RewardReceiver is IRewardReceiver, Initializable, OwnableUpgradeable, R
         _;
     }
 
-    modifier onlyClient() {
-        require(client() == _msgSender(), "RewardReceiver: caller is not the client");
+    modifier onlyOwnerOrClient() {
+        require(
+            owner() == _msgSender() || client() == _msgSender(), "RewardReceiver: caller is not the owner or client"
+        );
         _;
     }
 
@@ -61,7 +64,7 @@ contract RewardReceiver is IRewardReceiver, Initializable, OwnableUpgradeable, R
     }
 
     modifier notPendingState() {
-        require(pendingCommission == 0 && pendingWithdrawalThreshold == 0, "RewardReceiver: pending state");
+        require(pendingCommission == 0 && !_hasPendingWithdrawalThreshold, "RewardReceiver: pending state");
         _;
     }
 
@@ -116,7 +119,7 @@ contract RewardReceiver is IRewardReceiver, Initializable, OwnableUpgradeable, R
         claimClient(payable(_client));
     }
 
-    function claimClient(address payable recipient) public onlyClient nonReentrant {
+    function claimClient(address payable recipient) public onlyOwnerOrClient nonReentrant {
         require(recipient != address(0), "RewardReceiver: recipient is the zero address");
 
         uint256 amount = claimableClient;
@@ -135,8 +138,7 @@ contract RewardReceiver is IRewardReceiver, Initializable, OwnableUpgradeable, R
         claimProvider(payable(_provider));
     }
 
-    function claimProvider(address payable recipient) public nonReentrant {
-        require(provider() == _msgSender(), "RewardReceiver: caller is not the provider");
+    function claimProvider(address payable recipient) public onlyOwnerOrProvider nonReentrant {
         _claimProvider(recipient);
     }
 
@@ -147,12 +149,12 @@ contract RewardReceiver is IRewardReceiver, Initializable, OwnableUpgradeable, R
     }
 
     function proposeNewWithdrawalThreshold(uint256 newWithdrawalThreshold) external onlyOwnerOrProvider {
-        _checkValidWithdrawalThreshold(newWithdrawalThreshold);
         pendingWithdrawalThreshold = newWithdrawalThreshold;
+        _hasPendingWithdrawalThreshold = true;
         emit WithdrawalThresholdProposed(_msgSender(), newWithdrawalThreshold);
     }
 
-    function acceptNewCommission() external onlyClient {
+    function acceptNewCommission() external onlyOwnerOrClient {
         _checkValidPercentange(pendingCommission);
         uint96 previousCommission = _commission;
         _commission = pendingCommission;
@@ -160,11 +162,12 @@ contract RewardReceiver is IRewardReceiver, Initializable, OwnableUpgradeable, R
         emit CommissionAccepted(_msgSender(), previousCommission, _commission);
     }
 
-    function acceptNewWithdrawalThreshold() external onlyClient {
-        _checkValidWithdrawalThreshold(pendingWithdrawalThreshold);
+    function acceptNewWithdrawalThreshold() external onlyOwnerOrClient {
+        require(_hasPendingWithdrawalThreshold, "RewardReceiver: no pending withdrawal threshold");
         uint256 previousWithdrawalThreshold = _withdrawalThreshold;
         _withdrawalThreshold = pendingWithdrawalThreshold;
         pendingWithdrawalThreshold = 0;
+        _hasPendingWithdrawalThreshold = false;
         emit WithdrawalThresholdAccepted(_msgSender(), previousWithdrawalThreshold, _withdrawalThreshold);
     }
 
@@ -176,9 +179,10 @@ contract RewardReceiver is IRewardReceiver, Initializable, OwnableUpgradeable, R
     }
 
     function cancelNewWithdrawalThreshold() external onlyOwnerOrProvider {
-        _checkValidWithdrawalThreshold(pendingWithdrawalThreshold);
+        require(_hasPendingWithdrawalThreshold, "RewardReceiver: no pending withdrawal threshold");
         uint256 cancelledWithdrawalThreshold = pendingWithdrawalThreshold;
         pendingWithdrawalThreshold = 0;
+        _hasPendingWithdrawalThreshold = false;
         emit WithdrawalThresholdCancelled(_msgSender(), cancelledWithdrawalThreshold);
     }
 
@@ -188,10 +192,6 @@ contract RewardReceiver is IRewardReceiver, Initializable, OwnableUpgradeable, R
 
     function withdrawalThreshold() external view returns (uint256) {
         return _withdrawalThreshold;
-    }
-
-    function addValidator(bytes memory pubkey) external onlyStakePadOrProviderOrAdmin {
-        _addValidator(pubkey, 0);
     }
 
     function addValidator(bytes memory pubkey, uint256 protectedPrincipal) external onlyStakePadOrProviderOrAdmin {
@@ -221,13 +221,19 @@ contract RewardReceiver is IRewardReceiver, Initializable, OwnableUpgradeable, R
         uint256 len = validators.length;
         require(index < len, "RewardReceiver : invalid index");
         bytes memory removedValidator = validators[index];
-        uint256 removedPrincipal = _validatorPrincipals[index];
+        uint256 removedPrincipal = 0;
+        uint256 principalLen = _validatorPrincipals.length;
+        if (index < principalLen) {
+            removedPrincipal = _validatorPrincipals[index];
+            if (index != principalLen - 1) {
+                _validatorPrincipals[index] = _validatorPrincipals[principalLen - 1];
+            }
+            _validatorPrincipals.pop();
+        }
         if (index != len - 1) {
             validators[index] = validators[len - 1];
-            _validatorPrincipals[index] = _validatorPrincipals[len - 1];
         }
         validators.pop();
-        _validatorPrincipals.pop();
         _decreaseProtectedPrincipal(removedPrincipal);
         emit ValidatorRemoved(index, removedValidator, removedPrincipal, _withdrawalThreshold);
     }
@@ -241,8 +247,10 @@ contract RewardReceiver is IRewardReceiver, Initializable, OwnableUpgradeable, R
 
     function percentageWithdraw(uint96 percentage) external onlyOwner {
         _checkValidPercentange(percentage);
-        uint256 balance = _unallocatedBalance();
-        uint256 amounToWithdraw = (balance * percentage) / BASIS_PTS;
+        uint256 unaccountedRewards = _unaccountedRewards();
+        uint256 availableBalance = _unallocatedBalance();
+        uint256 withdrawable = unaccountedRewards < availableBalance ? unaccountedRewards : availableBalance;
+        uint256 amounToWithdraw = (withdrawable * percentage) / BASIS_PTS;
         require(amounToWithdraw > 0, "RewardReceiver: amount too low");
         totalClaimedProvider += amounToWithdraw;
         _feeAccountedRewards += amounToWithdraw;
@@ -324,6 +332,12 @@ contract RewardReceiver is IRewardReceiver, Initializable, OwnableUpgradeable, R
         return address(this).balance + totalClaimedClient + totalClaimedProvider;
     }
 
+    function _unaccountedRewards() internal view returns (uint256) {
+        uint256 totalReceived = _lifetimeReceived();
+        uint256 totalRewards = totalReceived > _withdrawalThreshold ? totalReceived - _withdrawalThreshold : 0;
+        return totalRewards > _feeAccountedRewards ? totalRewards - _feeAccountedRewards : 0;
+    }
+
     function _decreaseProtectedPrincipal(uint256 protectedPrincipal) internal {
         if (protectedPrincipal == 0) {
             return;
@@ -344,7 +358,4 @@ contract RewardReceiver is IRewardReceiver, Initializable, OwnableUpgradeable, R
         require(newPercentage > 0 && newPercentage <= BASIS_PTS, "RewardReceiver: invalid percentage");
     }
 
-    function _checkValidWithdrawalThreshold(uint256 newWithdrawalThreshold) internal pure {
-        require(newWithdrawalThreshold > 0, "RewardReceiver: invalid withdrawal threshold");
-    }
 }

--- a/src/StakePadV1.sol
+++ b/src/StakePadV1.sol
@@ -85,7 +85,7 @@ contract StakePadV1 is IStakePad, Initializable, UUPSUpgradeable, OwnableUpgrade
         for (uint256 i = 0; i < DepositDataArray.length; ++i) {
             StakePadUtils.BeaconDepositParams calldata DepositData = DepositDataArray[i];
             _validateWithdrawalCredentials(DepositData.withdrawal_credentials);
-            _addValidatorPubKey(DepositData.pubkey, DepositData.withdrawal_credentials);
+            _addValidatorPubKey(DepositData.pubkey, DepositData.withdrawal_credentials, DepositData.depositValue);
             beaconDeposit.deposit{value: DepositData.depositValue}(
                 DepositData.pubkey,
                 DepositData.withdrawal_credentials,
@@ -107,8 +107,11 @@ contract StakePadV1 is IStakePad, Initializable, UUPSUpgradeable, OwnableUpgrade
      * @dev Retrieve any mistakenly sent funds to this contract
      */
     function retrieveETH() external onlyOwner {
-        (bool success,) = owner().call{value: address(this).balance}("");
+        uint256 amount = address(this).balance;
+        address recipient = owner();
+        (bool success,) = recipient.call{value: amount}("");
         require(success, "StakePadV1: retrieveETH failed");
+        emit ETHRetrieved(recipient, amount);
     }
 
     function owner() public view override(OwnableUpgradeable, IStakePad) returns (address) {
@@ -165,12 +168,14 @@ contract StakePadV1 is IStakePad, Initializable, UUPSUpgradeable, OwnableUpgrade
      */
     function _updateRewardReceiverImpl(address newRewardReceiverImpl) internal {
         require(newRewardReceiverImpl != address(0), "StakePadV1: new implementation is the zero address");
+        address previousRewardReceiverImpl = _rewardReceiverImpl;
         _rewardReceiverImpl = newRewardReceiverImpl;
+        emit RewardReceiverImplUpdated(previousRewardReceiverImpl, newRewardReceiverImpl);
     }
 
-    function _addValidatorPubKey(bytes calldata pubkey, bytes calldata withdrawal_credentials) internal {
+    function _addValidatorPubKey(bytes calldata pubkey, bytes calldata withdrawal_credentials, uint256 depositValue) internal {
         require(pubkey.length == 48, "StakePadV1: invalid pubkey length");
-        IRewardReceiver(address(bytes20(withdrawal_credentials[12:]))).addValidator(pubkey);
+        IRewardReceiver(address(bytes20(withdrawal_credentials[12:]))).addValidator(pubkey, depositValue);
     }
 
     /**

--- a/src/interfaces/IRewardReceiver.sol
+++ b/src/interfaces/IRewardReceiver.sol
@@ -5,6 +5,30 @@ pragma solidity 0.8.22;
 interface IRewardReceiver {
     event RewardSent(address indexed, uint256);
     event CommissionSent(address indexed, uint256);
+    event FundsReceived(address indexed sender, uint256 amount, uint256 balanceAfter);
+    event WithdrawalAllocated(
+        address indexed client,
+        address indexed provider,
+        uint256 principalAmount,
+        uint256 grossRewardAmount,
+        uint256 commissionAmount,
+        uint256 clientAmount,
+        uint256 providerAmount
+    );
+    event ClientClaimed(address indexed client, address indexed recipient, uint256 amount);
+    event ProviderClaimed(address indexed provider, address indexed recipient, uint256 amount);
+    event CommissionProposed(address indexed proposer, uint96 commission);
+    event CommissionAccepted(address indexed client, uint96 previousCommission, uint96 newCommission);
+    event CommissionCancelled(address indexed canceller, uint96 commission);
+    event WithdrawalThresholdProposed(address indexed proposer, uint256 withdrawalThreshold);
+    event WithdrawalThresholdAccepted(
+        address indexed client, uint256 previousWithdrawalThreshold, uint256 newWithdrawalThreshold
+    );
+    event WithdrawalThresholdCancelled(address indexed canceller, uint256 withdrawalThreshold);
+    event ValidatorAdded(bytes pubkey, uint256 protectedPrincipal, uint256 protectedPrincipalAfter);
+    event ValidatorRemoved(uint256 indexed index, bytes pubkey);
+    event StakePadChanged(address indexed previousStakePad, address indexed newStakePad);
+    event PercentageWithdrawn(address indexed caller, address indexed provider, uint96 percentage, uint256 amount);
 
     function initialize(address, address, uint96, address) external;
 
@@ -12,9 +36,19 @@ interface IRewardReceiver {
 
     function addValidator(bytes memory) external;
 
+    function addValidator(bytes memory, uint256) external;
+
     function getValidators() external returns (bytes[] memory);
 
     function withdraw() external;
+
+    function claimClient() external;
+
+    function claimClient(address payable) external;
+
+    function claimProvider() external;
+
+    function claimProvider(address payable) external;
 
     function proposeNewCommission(uint96) external;
 

--- a/src/interfaces/IRewardReceiver.sol
+++ b/src/interfaces/IRewardReceiver.sol
@@ -36,8 +36,6 @@ interface IRewardReceiver {
 
     function transferOwnership(address) external;
 
-    function addValidator(bytes memory) external;
-
     function addValidator(bytes memory, uint256) external;
 
     function getValidators() external returns (bytes[] memory);

--- a/src/interfaces/IRewardReceiver.sol
+++ b/src/interfaces/IRewardReceiver.sol
@@ -26,7 +26,9 @@ interface IRewardReceiver {
     );
     event WithdrawalThresholdCancelled(address indexed canceller, uint256 withdrawalThreshold);
     event ValidatorAdded(bytes pubkey, uint256 protectedPrincipal, uint256 protectedPrincipalAfter);
-    event ValidatorRemoved(uint256 indexed index, bytes pubkey);
+    event ValidatorRemoved(
+        uint256 indexed index, bytes pubkey, uint256 protectedPrincipal, uint256 protectedPrincipalAfter
+    );
     event StakePadChanged(address indexed previousStakePad, address indexed newStakePad);
     event PercentageWithdrawn(address indexed caller, address indexed provider, uint96 percentage, uint256 amount);
 

--- a/src/interfaces/IStakePad.sol
+++ b/src/interfaces/IStakePad.sol
@@ -7,6 +7,8 @@ interface IStakePad {
     event NewRewardReceiver(
         uint256 indexed index, address rewardReceiver, address client, address provider, uint96 commission
     );
+    event RewardReceiverImplUpdated(address indexed previousImplementation, address indexed newImplementation);
+    event ETHRetrieved(address indexed recipient, uint256 amount);
 
     function fundValidators(StakePadUtils.BeaconDepositParams[] memory) external payable;
 

--- a/src/test/TestStakePadV1.sol
+++ b/src/test/TestStakePadV1.sol
@@ -135,7 +135,7 @@ contract TestStakePadV1 is IStakePad, Initializable, UUPSUpgradeable, OwnableUpg
 
     function _addValidatorPubKey(bytes calldata pubkey, bytes calldata withdrawal_credentials) internal {
         require(pubkey.length == 48, "StakePadV1: invalid pubkey length");
-        IRewardReceiver(address(bytes20(withdrawal_credentials[12:]))).addValidator(pubkey);
+        IRewardReceiver(address(bytes20(withdrawal_credentials[12:]))).addValidator(pubkey, 0);
     }
 
     /**

--- a/src/test/TestStakePadV2.sol
+++ b/src/test/TestStakePadV2.sol
@@ -143,7 +143,7 @@ contract TestStakePadV2 is IStakePad, Initializable, UUPSUpgradeable, OwnableUpg
 
     function _addValidatorPubKey(bytes calldata pubkey, bytes calldata withdrawal_credentials) internal {
         require(pubkey.length == 48, "StakePadV1: invalid pubkey length");
-        IRewardReceiver(address(bytes20(withdrawal_credentials[12:]))).addValidator(pubkey);
+        IRewardReceiver(address(bytes20(withdrawal_credentials[12:]))).addValidator(pubkey, 0);
     }
 
     /**

--- a/test/RewardReceiver.t.sol
+++ b/test/RewardReceiver.t.sol
@@ -251,6 +251,18 @@ contract RewardReceiverTest is TestUtils {
             address(rewardReceiver).balance == 0,
             "rewardReceiver not empty"
         );
+        require(
+            rewardReceiver.totalClaimedProvider() == 16 ether,
+            "percentage withdraw did not record provider claim"
+        );
+        require(
+            rewardReceiver.feeAccountedRewards() == 16 ether,
+            "percentage withdraw did not account rewards"
+        );
+        require(
+            rewardReceiver.lifetimeReceived() == 16 ether,
+            "percentage withdraw changed lifetime received"
+        );
     }
 
     function testWithdraw() public {
@@ -726,6 +738,17 @@ contract RewardReceiverTest is TestUtils {
             rewardReceiver.withdrawalThreshold() == 32 ether,
             "protected principal not updated"
         );
+
+        vm.prank(testStakePad);
+        rewardReceiver.removeValidator(1);
+        require(
+            rewardReceiver.withdrawalThreshold() == 0,
+            "protected principal not released on remove"
+        );
+        require(
+            rewardReceiver.getValidators().length == 1,
+            "validator not removed"
+        );
     }
 
     function testRemoveValidators() public {
@@ -783,6 +806,29 @@ contract RewardReceiverTest is TestUtils {
         require(
             keccak256(validator3) == keccak256("0x1234567"),
             "validators not removed correctly"
+        );
+    }
+
+    function testRemoveValidatorDoesNotDropAccountedPrincipal() public {
+        vm.prank(testStakePad);
+        rewardReceiver.addValidator("0xabc", 32 ether);
+
+        vm.deal(address(rewardReceiver), 32.2 ether);
+        vm.prank(owner);
+        rewardReceiver.withdraw();
+        vm.prank(provider);
+        rewardReceiver.claimProvider();
+        vm.prank(client);
+        rewardReceiver.claimClient();
+
+        uint256 thresholdAfterExit = rewardReceiver.withdrawalThreshold();
+        require(thresholdAfterExit == 32 ether, "threshold should still protect returned principal");
+
+        vm.prank(testStakePad);
+        rewardReceiver.removeValidator(0);
+        require(
+            rewardReceiver.withdrawalThreshold() == 32 ether,
+            "remove after unstake must not unprotect already-received principal"
         );
     }
 

--- a/test/RewardReceiver.t.sol
+++ b/test/RewardReceiver.t.sol
@@ -213,8 +213,10 @@ contract RewardReceiverTest is TestUtils {
             testStakePad
         );
         vm.prank(owner);
-        vm.expectRevert("RewardReceiver: transfer failed");
         newRewardReceiver.withdraw();
+        vm.prank(address(sampleAttackContract));
+        vm.expectRevert("RewardReceiver: transfer failed");
+        newRewardReceiver.claimClient();
     }
 
     function testWithdrawPercentage() public {
@@ -261,10 +263,10 @@ contract RewardReceiverTest is TestUtils {
 
         // fails to withdraw when balance is too low
         vm.prank(owner);
-        vm.expectRevert("RewardReceiver: commission too low");
+        vm.expectRevert("RewardReceiver: no funds to allocate");
         rewardReceiver.withdraw();
 
-        // fails if the transfer function fails
+        // allocation succeeds even when the client cannot receive ETH
         RewardReceiver testRewardReceiver = new RewardReceiver();
         ContractWithdrawerNoReceive sampleContractWithdrawer = new ContractWithdrawerNoReceive();
         vm.prank(owner);
@@ -276,8 +278,15 @@ contract RewardReceiverTest is TestUtils {
         );
         vm.deal(address(testRewardReceiver), TEST_WITHDRAWAL_THRESHOLD * 2);
         vm.prank(owner);
-        vm.expectRevert("RewardReceiver: transfer failed");
         testRewardReceiver.withdraw();
+        require(testRewardReceiver.claimableClient() > 0, "client claimable not allocated");
+        require(testRewardReceiver.claimableProvider() > 0, "provider claimable not allocated");
+
+        vm.prank(provider);
+        testRewardReceiver.claimProvider();
+        vm.prank(address(sampleContractWithdrawer));
+        vm.expectRevert("RewardReceiver: transfer failed");
+        testRewardReceiver.claimClient();
 
         // succeeds to withdraw if the transfer function succeeds
         testRewardReceiver = new RewardReceiver();
@@ -292,6 +301,10 @@ contract RewardReceiverTest is TestUtils {
         vm.deal(address(testRewardReceiver), TEST_WITHDRAWAL_THRESHOLD * 2);
         vm.prank(owner);
         testRewardReceiver.withdraw();
+        vm.prank(provider);
+        testRewardReceiver.claimProvider();
+        vm.prank(address(sampleContractWithdrawerReceive));
+        testRewardReceiver.claimClient();
 
         // CHECK AMOUNTS transferred
         vm.deal(address(rewardReceiver), 16 ether - 1);
@@ -304,6 +317,10 @@ contract RewardReceiverTest is TestUtils {
         // ----PERFORM CALL---
         vm.prank(owner);
         rewardReceiver.withdraw();
+        vm.prank(provider);
+        rewardReceiver.claimProvider();
+        vm.prank(client);
+        rewardReceiver.claimClient();
 
         // ----DATA AFTER----
         uint256 rewardReceiverBalanceAfter = address(rewardReceiver).balance;
@@ -336,32 +353,45 @@ contract RewardReceiverTest is TestUtils {
         providerBalanceBefore = address(provider).balance;
         clientBalanceBefore = address(client).balance;
 
-        // ----PERFORM CALL--- FAILS
+        // ----PERFORM CALL--- succeeds and assigns dust to the client
         vm.prank(owner);
-        vm.expectRevert("RewardReceiver: commission too low");
         rewardReceiver.withdraw();
+        require(rewardReceiver.claimableClient() == 1, "dust not allocated to client");
+        require(rewardReceiver.claimableProvider() == 0, "dust allocated to provider");
+        vm.prank(client);
+        rewardReceiver.claimClient();
+        require(address(rewardReceiver).balance == 0, "rewardReceiver not empty");
+        require(clientBalanceBefore + 1 == address(client).balance, "dust not claimed");
+
+        RewardReceiver thresholdReceiver = new RewardReceiver();
+        vm.prank(owner);
+        thresholdReceiver.initialize(client, provider, commission, testStakePad);
 
         // CHECK AMOUNTS transferred
-        vm.deal(address(rewardReceiver), 20 ether);
+        vm.deal(address(thresholdReceiver), 20 ether);
 
         // ----DATA BEFORE----
-        rewardReceiverBalanceBefore = address(rewardReceiver).balance;
+        rewardReceiverBalanceBefore = address(thresholdReceiver).balance;
         providerBalanceBefore = address(provider).balance;
         clientBalanceBefore = address(client).balance;
 
         // ----UPDATE WITHDRAWAL THRESHOLD----
 
         vm.prank(owner);
-        rewardReceiver.proposeNewWithdrawalThreshold(TEST_WITHDRAWAL_THRESHOLD);
+        thresholdReceiver.proposeNewWithdrawalThreshold(TEST_WITHDRAWAL_THRESHOLD);
         vm.prank(client);
-        rewardReceiver.acceptNewWithdrawalThreshold();
+        thresholdReceiver.acceptNewWithdrawalThreshold();
 
-        // ----PERFORM CALL--- FAILS
+        // ----PERFORM CALL---
         vm.prank(owner);
-        rewardReceiver.withdraw();
+        thresholdReceiver.withdraw();
+        vm.prank(provider);
+        thresholdReceiver.claimProvider();
+        vm.prank(client);
+        thresholdReceiver.claimClient();
 
         // ----DATA AFTER----
-        rewardReceiverBalanceAfter = address(rewardReceiver).balance;
+        rewardReceiverBalanceAfter = address(thresholdReceiver).balance;
         providerBalanceAfter = address(provider).balance;
         clientBalanceAfter = address(client).balance;
 
@@ -369,7 +399,7 @@ contract RewardReceiverTest is TestUtils {
         require(
             providerBalanceBefore +
                 ((rewardReceiverBalanceBefore - TEST_WITHDRAWAL_THRESHOLD) *
-                    rewardReceiver.commission()) /
+                    thresholdReceiver.commission()) /
                 BASIS_PTS ==
                 providerBalanceAfter,
             "withdrawn amount not correct"
@@ -379,11 +409,26 @@ contract RewardReceiverTest is TestUtils {
             clientBalanceBefore +
                 (rewardReceiverBalanceBefore) -
                 ((rewardReceiverBalanceBefore - TEST_WITHDRAWAL_THRESHOLD) *
-                    rewardReceiver.commission()) /
+                    thresholdReceiver.commission()) /
                 BASIS_PTS ==
                 clientBalanceAfter,
             "withdrawn amount not correct"
         );
+    }
+
+    function testReceiveAndWithdrawEmitStructuredEvents() public {
+        vm.recordLogs();
+        vm.prank(owner);
+        (bool success,) = address(rewardReceiver).call{value: 1 ether}("");
+        require(success, "funding failed");
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+        require(entries.length == 1, "receive event not emitted");
+
+        vm.recordLogs();
+        vm.prank(owner);
+        rewardReceiver.withdraw();
+        entries = vm.getRecordedLogs();
+        require(entries.length == 1, "allocation event not emitted");
     }
 
     function testCannotWithdrawWhenPending() public {
@@ -426,7 +471,7 @@ contract RewardReceiverTest is TestUtils {
     }
 
     function testFuzzWithdrawal(uint256 balanceOfContract) public {
-        vm.assume(balanceOfContract < MAX_UINT / rewardReceiver.commission());
+        vm.assume(balanceOfContract < 1_000_000 ether);
         // CHECK AMOUNTS transferred
         vm.deal(address(rewardReceiver), balanceOfContract);
 
@@ -450,19 +495,21 @@ contract RewardReceiverTest is TestUtils {
                 ((balanceOfContract - TEST_WITHDRAWAL_THRESHOLD) *
                     rewardReceiver.commission()) /
                 BASIS_PTS;
-        } else {
-            commission =
-                (balanceOfContract * rewardReceiver.commission()) /
-                BASIS_PTS;
         }
 
         // ----PERFORM CALL WITH CONDITIONAL REVERT---
         vm.prank(owner);
-        if (commission == 0) {
-            vm.expectRevert("RewardReceiver: commission too low");
+        if (balanceOfContract == 0) {
+            vm.expectRevert("RewardReceiver: no funds to allocate");
             rewardReceiver.withdraw();
         } else {
             rewardReceiver.withdraw();
+            if (commission > 0) {
+                vm.prank(provider);
+                rewardReceiver.claimProvider();
+            }
+            vm.prank(client);
+            rewardReceiver.claimClient();
             // ----DATA AFTER----
             uint256 rewardReceiverBalanceAfter = address(rewardReceiver)
                 .balance;
@@ -486,6 +533,173 @@ contract RewardReceiverTest is TestUtils {
         }
     }
 
+    function testUnauthorizedCallerCannotClaimClientOrProvider() public {
+        vm.deal(address(rewardReceiver), 10 ether);
+        vm.prank(owner);
+        rewardReceiver.withdraw();
+
+        vm.prank(account1);
+        vm.expectRevert("RewardReceiver: caller is not the client");
+        rewardReceiver.claimClient();
+
+        vm.prank(account1);
+        vm.expectRevert("RewardReceiver: caller is not the client");
+        rewardReceiver.claimClient(payable(account1));
+
+        vm.prank(account1);
+        vm.expectRevert("RewardReceiver: caller is not the provider");
+        rewardReceiver.claimProvider();
+
+        vm.prank(account1);
+        vm.expectRevert("RewardReceiver: caller is not the provider");
+        rewardReceiver.claimProvider(payable(account1));
+    }
+
+    function testClientAndProviderCanClaimToAlternateRecipients() public {
+        uint256 balanceOfContract = 10 ether;
+        uint256 expectedProviderAmount = (balanceOfContract * rewardReceiver.commission()) / BASIS_PTS;
+        uint256 expectedClientAmount = balanceOfContract - expectedProviderAmount;
+
+        vm.deal(address(rewardReceiver), balanceOfContract);
+        vm.prank(owner);
+        rewardReceiver.withdraw();
+
+        uint256 clientBalanceBefore = address(client).balance;
+        uint256 providerBalanceBefore = address(provider).balance;
+        uint256 clientRecipientBalanceBefore = address(account1).balance;
+        uint256 providerRecipientBalanceBefore = address(account2).balance;
+
+        vm.prank(client);
+        rewardReceiver.claimClient(payable(account1));
+
+        vm.prank(provider);
+        rewardReceiver.claimProvider(payable(account2));
+
+        require(address(account1).balance == clientRecipientBalanceBefore + expectedClientAmount, "client recipient incorrect");
+        require(address(account2).balance == providerRecipientBalanceBefore + expectedProviderAmount, "provider recipient incorrect");
+        require(address(client).balance == clientBalanceBefore, "client should not receive redirected claim");
+        require(address(provider).balance == providerBalanceBefore, "provider should not receive redirected claim");
+        require(rewardReceiver.claimableClient() == 0, "client claimable not cleared");
+        require(rewardReceiver.claimableProvider() == 0, "provider claimable not cleared");
+        require(rewardReceiver.totalClaimedClient() == expectedClientAmount, "total claimed client incorrect");
+        require(rewardReceiver.totalClaimedProvider() == expectedProviderAmount, "total claimed provider incorrect");
+    }
+
+    function testClaimFailureDoesNotClearClaimableBalances() public {
+        ContractWithdrawerNoReceive failingRecipient = new ContractWithdrawerNoReceive();
+        uint256 balanceOfContract = 10 ether;
+
+        vm.deal(address(rewardReceiver), balanceOfContract);
+        vm.prank(owner);
+        rewardReceiver.withdraw();
+
+        uint256 claimableClientBefore = rewardReceiver.claimableClient();
+        uint256 claimableProviderBefore = rewardReceiver.claimableProvider();
+
+        vm.prank(client);
+        vm.expectRevert("RewardReceiver: transfer failed");
+        rewardReceiver.claimClient(payable(address(failingRecipient)));
+
+        require(rewardReceiver.claimableClient() == claimableClientBefore, "failed client claim cleared balance");
+        require(rewardReceiver.totalClaimedClient() == 0, "failed client claim updated total");
+
+        vm.prank(provider);
+        vm.expectRevert("RewardReceiver: transfer failed");
+        rewardReceiver.claimProvider(payable(address(failingRecipient)));
+
+        require(rewardReceiver.claimableProvider() == claimableProviderBefore, "failed provider claim cleared balance");
+        require(rewardReceiver.totalClaimedProvider() == 0, "failed provider claim updated total");
+    }
+
+    function testMultipleWithdrawsBeforeClaimsDoNotDoubleCountCommission() public {
+        uint256 firstBalance = 10 ether;
+        uint256 secondBalance = 5 ether;
+        uint256 firstCommission = (firstBalance * rewardReceiver.commission()) / BASIS_PTS;
+        uint256 secondCommission = (secondBalance * rewardReceiver.commission()) / BASIS_PTS;
+
+        vm.deal(address(rewardReceiver), firstBalance);
+        vm.prank(owner);
+        rewardReceiver.withdraw();
+
+        vm.deal(address(rewardReceiver), firstBalance + secondBalance);
+        vm.prank(owner);
+        rewardReceiver.withdraw();
+
+        require(
+            rewardReceiver.claimableProvider() == firstCommission + secondCommission,
+            "provider commission double-counted"
+        );
+        require(
+            rewardReceiver.claimableClient() == firstBalance + secondBalance - firstCommission - secondCommission,
+            "client claimable incorrect"
+        );
+        require(rewardReceiver.feeAccountedRewards() == firstBalance + secondBalance, "fee accounted rewards incorrect");
+
+        vm.prank(provider);
+        rewardReceiver.claimProvider();
+        vm.prank(client);
+        rewardReceiver.claimClient();
+
+        require(address(rewardReceiver).balance == 0, "rewardReceiver not empty");
+    }
+
+    function testMultipleReceiveWithdrawClaimCyclesKeepAccountingCorrect() public {
+        uint256 withdrawalThreshold = 16 ether;
+        uint256 firstReceived = 17 ether;
+        uint256 secondReceived = 2 ether;
+        uint256 firstCommission = ((firstReceived - withdrawalThreshold) * rewardReceiver.commission()) / BASIS_PTS;
+        uint256 secondCommission = (secondReceived * rewardReceiver.commission()) / BASIS_PTS;
+
+        vm.prank(owner);
+        rewardReceiver.proposeNewWithdrawalThreshold(withdrawalThreshold);
+        vm.prank(client);
+        rewardReceiver.acceptNewWithdrawalThreshold();
+
+        uint256 providerBalanceBefore = address(provider).balance;
+        uint256 clientBalanceBefore = address(client).balance;
+
+        vm.prank(owner);
+        (bool success,) = address(rewardReceiver).call{value: firstReceived}("");
+        require(success, "first receive failed");
+
+        vm.prank(owner);
+        rewardReceiver.withdraw();
+        vm.prank(provider);
+        rewardReceiver.claimProvider();
+        vm.prank(client);
+        rewardReceiver.claimClient();
+
+        require(address(provider).balance == providerBalanceBefore + firstCommission, "first provider claim incorrect");
+        require(address(client).balance == clientBalanceBefore + firstReceived - firstCommission, "first client claim incorrect");
+        require(rewardReceiver.feeAccountedRewards() == firstReceived - withdrawalThreshold, "first rewards incorrect");
+
+        vm.prank(owner);
+        (success,) = address(rewardReceiver).call{value: secondReceived}("");
+        require(success, "second receive failed");
+
+        vm.prank(owner);
+        rewardReceiver.withdraw();
+        vm.prank(provider);
+        rewardReceiver.claimProvider();
+        vm.prank(client);
+        rewardReceiver.claimClient();
+
+        require(
+            address(provider).balance == providerBalanceBefore + firstCommission + secondCommission,
+            "second provider claim incorrect"
+        );
+        require(
+            address(client).balance == clientBalanceBefore + firstReceived + secondReceived - firstCommission - secondCommission,
+            "second client claim incorrect"
+        );
+        require(rewardReceiver.totalClaimedProvider() == firstCommission + secondCommission, "provider total incorrect");
+        require(
+            rewardReceiver.totalClaimedClient() == firstReceived + secondReceived - firstCommission - secondCommission,
+            "client total incorrect"
+        );
+        require(address(rewardReceiver).balance == 0, "rewardReceiver not empty");
+    }
+
     function testAddValidators() public {
         vm.prank(account3);
         vm.expectRevert(
@@ -504,6 +718,13 @@ contract RewardReceiverTest is TestUtils {
             keccak256(rewardReceiver.getValidators()[0]) ==
                 keccak256("0x12345"),
             "validators not added correctly"
+        );
+
+        vm.prank(testStakePad);
+        rewardReceiver.addValidator("0x123456", 32 ether);
+        require(
+            rewardReceiver.withdrawalThreshold() == 32 ether,
+            "protected principal not updated"
         );
     }
 

--- a/test/RewardReceiver.t.sol
+++ b/test/RewardReceiver.t.sol
@@ -162,15 +162,16 @@ contract RewardReceiverTest is TestUtils {
             TEST_WITHDRAWAL_THRESHOLD * 2
         );
 
-        // fails to propose a newWithdrawalThreshold if this is 0
+        // accepts a pending zero threshold
         vm.prank(owner);
-        vm.expectRevert("RewardReceiver: invalid withdrawal threshold");
-        rewardReceiver.proposeNewWithdrawalThreshold(0);
-
-        // faiils to accept a newWithdrawalThreshold when the newWithdrawalThreshold is 0
-        vm.prank(client);
-        vm.expectRevert("RewardReceiver: invalid withdrawal threshold");
+        vm.expectRevert("RewardReceiver: no pending withdrawal threshold");
         rewardReceiver.acceptNewWithdrawalThreshold();
+
+        vm.prank(owner);
+        rewardReceiver.proposeNewWithdrawalThreshold(0);
+        vm.prank(client);
+        rewardReceiver.acceptNewWithdrawalThreshold();
+        require(rewardReceiver.withdrawalThreshold() == 0, "zero threshold not accepted");
 
         // accepts a new incoming newWithdrawalThreshold
         uint256 ss = vm.snapshot();
@@ -263,6 +264,19 @@ contract RewardReceiverTest is TestUtils {
             rewardReceiver.lifetimeReceived() == 16 ether,
             "percentage withdraw changed lifetime received"
         );
+    }
+
+    function testPercentageWithdrawCannotTakePrincipal() public {
+        vm.prank(testStakePad);
+        rewardReceiver.addValidator("0xabc", 32 ether);
+        vm.deal(address(rewardReceiver), 32.2 ether);
+
+        vm.prank(owner);
+        rewardReceiver.percentageWithdraw(10000);
+
+        require(address(rewardReceiver).balance == 32 ether, "percentage withdraw took principal");
+        require(rewardReceiver.totalClaimedProvider() == 0.2 ether, "unaccounted rewards not sent to provider");
+        require(rewardReceiver.feeAccountedRewards() == 0.2 ether, "unaccounted rewards not fee-accounted");
     }
 
     function testWithdraw() public {
@@ -551,20 +565,56 @@ contract RewardReceiverTest is TestUtils {
         rewardReceiver.withdraw();
 
         vm.prank(account1);
-        vm.expectRevert("RewardReceiver: caller is not the client");
+        vm.expectRevert("RewardReceiver: caller is not the owner or client");
         rewardReceiver.claimClient();
 
         vm.prank(account1);
-        vm.expectRevert("RewardReceiver: caller is not the client");
+        vm.expectRevert("RewardReceiver: caller is not the owner or client");
         rewardReceiver.claimClient(payable(account1));
 
         vm.prank(account1);
-        vm.expectRevert("RewardReceiver: caller is not the provider");
+        vm.expectRevert("RewardReceiver: caller is not the owner or provider");
         rewardReceiver.claimProvider();
 
         vm.prank(account1);
-        vm.expectRevert("RewardReceiver: caller is not the provider");
+        vm.expectRevert("RewardReceiver: caller is not the owner or provider");
         rewardReceiver.claimProvider(payable(account1));
+    }
+
+    function testOwnerCanClaimAndAcceptOnBehalfOfParties() public {
+        vm.deal(address(rewardReceiver), 10 ether);
+        vm.prank(owner);
+        rewardReceiver.withdraw();
+
+        uint256 expectedProviderAmount = (10 ether * rewardReceiver.commission()) / BASIS_PTS;
+        uint256 expectedClientAmount = 10 ether - expectedProviderAmount;
+        uint256 clientBalanceBefore = address(client).balance;
+        uint256 providerBalanceBefore = address(provider).balance;
+
+        vm.prank(owner);
+        rewardReceiver.claimClient();
+        vm.prank(owner);
+        rewardReceiver.claimProvider();
+
+        require(address(client).balance == clientBalanceBefore + expectedClientAmount, "owner client claim incorrect");
+        require(
+            address(provider).balance == providerBalanceBefore + expectedProviderAmount, "owner provider claim incorrect"
+        );
+
+        vm.prank(owner);
+        rewardReceiver.proposeNewCommission(commission * 2);
+        vm.prank(owner);
+        rewardReceiver.acceptNewCommission();
+        require(rewardReceiver.commission() == commission * 2, "owner could not accept commission");
+
+        vm.prank(owner);
+        rewardReceiver.proposeNewWithdrawalThreshold(TEST_WITHDRAWAL_THRESHOLD);
+        vm.prank(owner);
+        rewardReceiver.acceptNewWithdrawalThreshold();
+        require(
+            rewardReceiver.withdrawalThreshold() == TEST_WITHDRAWAL_THRESHOLD,
+            "owner could not accept withdrawal threshold"
+        );
     }
 
     function testClientAndProviderCanClaimToAlternateRecipients() public {
@@ -717,10 +767,10 @@ contract RewardReceiverTest is TestUtils {
         vm.expectRevert(
             "RewardReceiver: caller is not stakePad or provider or owner"
         );
-        rewardReceiver.addValidator("0x1234");
+        rewardReceiver.addValidator("0x1234", 0);
 
         vm.prank(testStakePad);
-        rewardReceiver.addValidator("0x12345");
+        rewardReceiver.addValidator("0x12345", 0);
 
         require(
             rewardReceiver.getValidators().length == 1,
@@ -753,13 +803,13 @@ contract RewardReceiverTest is TestUtils {
 
     function testRemoveValidators() public {
         vm.prank(testStakePad);
-        rewardReceiver.addValidator("0x12345");
+        rewardReceiver.addValidator("0x12345", 0);
 
         vm.prank(testStakePad);
-        rewardReceiver.addValidator("0x123456");
+        rewardReceiver.addValidator("0x123456", 0);
 
         vm.prank(testStakePad);
-        rewardReceiver.addValidator("0x1234567");
+        rewardReceiver.addValidator("0x1234567", 0);
         require(
             rewardReceiver.getValidators().length == 3,
             "validators not added correctly"
@@ -855,37 +905,31 @@ contract RewardReceiverTest is TestUtils {
             vm.expectRevert("RewardReceiver: invalid percentage");
             rewardReceiver.proposeNewCommission(newInputCommission);
         } else {
-            if (newInputThreshold == 0) {
-                vm.prank(owner);
-                vm.expectRevert("RewardReceiver: invalid withdrawal threshold");
-                rewardReceiver.proposeNewWithdrawalThreshold(newInputThreshold);
-            } else {
-                vm.prank(owner);
-                rewardReceiver.proposeNewCommission(newInputCommission);
-                vm.prank(owner);
-                rewardReceiver.proposeNewWithdrawalThreshold(newInputThreshold);
-                vm.prank(client);
-                rewardReceiver.acceptNewWithdrawalThreshold();
-                vm.prank(client);
-                rewardReceiver.acceptNewCommission();
+            vm.prank(owner);
+            rewardReceiver.proposeNewCommission(newInputCommission);
+            vm.prank(owner);
+            rewardReceiver.proposeNewWithdrawalThreshold(newInputThreshold);
+            vm.prank(client);
+            rewardReceiver.acceptNewWithdrawalThreshold();
+            vm.prank(client);
+            rewardReceiver.acceptNewCommission();
 
-                require(
-                    rewardReceiver.commission() == newInputCommission,
-                    "commission not updated correctly"
-                );
-                require(
-                    rewardReceiver.withdrawalThreshold() == newInputThreshold,
-                    "withdrawalThreshold not updated correctly"
-                );
-                require(
-                    rewardReceiver.pendingCommission() == 0,
-                    "pendingCommission not updated correctly"
-                );
-                require(
-                    rewardReceiver.pendingWithdrawalThreshold() == 0,
-                    "pendingWithdrawalThreshold not updated correctly"
-                );
-            }
+            require(
+                rewardReceiver.commission() == newInputCommission,
+                "commission not updated correctly"
+            );
+            require(
+                rewardReceiver.withdrawalThreshold() == newInputThreshold,
+                "withdrawalThreshold not updated correctly"
+            );
+            require(
+                rewardReceiver.pendingCommission() == 0,
+                "pendingCommission not updated correctly"
+            );
+            require(
+                rewardReceiver.pendingWithdrawalThreshold() == 0,
+                "pendingWithdrawalThreshold not updated correctly"
+            );
         }
     }
 }

--- a/test/StakePad.t.sol
+++ b/test/StakePad.t.sol
@@ -1,6 +1,6 @@
 pragma solidity 0.8.22;
 
-import "forge-std/test.sol";
+import "forge-std/Test.sol";
 import "../src/RewardReceiver.sol";
 import "../src/StakePadV1.sol";
 import "../src/mocks/MockDepositContract.sol";
@@ -166,9 +166,63 @@ contract StakePadTest is TestUtils {
         entries = vm.getRecordedLogs();
 
         // check logs
-        require(entries.length == 1, "Incorrect number of events");
-        (,,,, bytes memory index) = abi.decode(entries[0].data, (bytes, bytes, bytes, bytes, bytes));
+        require(entries.length == 2, "Incorrect number of events");
+        (,,,, bytes memory index) = abi.decode(entries[1].data, (bytes, bytes, bytes, bytes, bytes));
         require(uint64(bytes8(_toBigEndian64(uint64(bytes8(index))))) == 0);
+        require(
+            RewardReceiver(payable(newRewardReceiver)).withdrawalThreshold() == 32 ether,
+            "principal not protected"
+        );
+
+        vm.deal(newRewardReceiver, 33 ether);
+        uint256 providerBalanceBefore = address(provider).balance;
+        uint256 clientBalanceBefore = address(client).balance;
+        uint256 expectedCommission = (1 ether * commission) / BASIS_PTS;
+
+        vm.prank(owner);
+        RewardReceiver(payable(newRewardReceiver)).withdraw();
+        vm.prank(provider);
+        RewardReceiver(payable(newRewardReceiver)).claimProvider();
+        vm.prank(client);
+        RewardReceiver(payable(newRewardReceiver)).claimClient();
+
+        require(address(provider).balance == providerBalanceBefore + expectedCommission, "principal was commissioned");
+        require(address(client).balance == clientBalanceBefore + 33 ether - expectedCommission, "client payout incorrect");
+    }
+
+    function testFundValidatorsProtectsActualDepositValue() public {
+        (StakePadUtils.BeaconDepositParams[] memory depositDataArray,) = _getRandomDepositParams(1);
+
+        address client = account1;
+        address provider = account2;
+        uint96 commission = 1000;
+        vm.prank(owner);
+        vm.recordLogs();
+        stakePad.deployNewRewardReceiver(client, provider, commission);
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+        (address newRewardReceiver,,,) =
+            abi.decode(entries[entries.length - 1].data, (address, address, address, uint96));
+
+        depositDataArray[0].depositValue = 64 ether;
+        depositDataArray[0].withdrawal_credentials = _withdrawalCredentialsFromAddress(newRewardReceiver);
+
+        vm.prank(account1);
+        stakePad.fundValidators{value: 64 ether}(depositDataArray);
+        require(
+            RewardReceiver(payable(newRewardReceiver)).withdrawalThreshold() == 64 ether,
+            "actual deposit value not protected"
+        );
+
+        vm.deal(newRewardReceiver, 65 ether);
+        uint256 providerBalanceBefore = address(provider).balance;
+        uint256 expectedCommission = (1 ether * commission) / BASIS_PTS;
+
+        vm.prank(owner);
+        RewardReceiver(payable(newRewardReceiver)).withdraw();
+        vm.prank(provider);
+        RewardReceiver(payable(newRewardReceiver)).claimProvider();
+
+        require(address(provider).balance == providerBalanceBefore + expectedCommission, "extra principal was commissioned");
     }
 
     function testOthers() public {

--- a/test/Utils.t.sol
+++ b/test/Utils.t.sol
@@ -1,6 +1,6 @@
 pragma solidity 0.8.22;
 
-import "forge-std/test.sol";
+import "forge-std/Test.sol";
 import "../src/utils/StakePadUtils.sol";
 
 contract TestUtils is Test {


### PR DESCRIPTION
## Summary

RewardReceiver now treats validator deposit value as protected principal and uses pull-based claims, so commission is only taken on rewards (e.g. 32.2 ETH landing together: 32 stays principal, 0.2 is rewards).

- `withdraw()` allocates unallocated ETH into `claimableClient` / `claimableProvider`; `claimClient` / `claimProvider` send funds. Owner can claim or accept pending commission/threshold on behalf of client and provider.
- `fundValidators` records each deposit as protected principal (`_withdrawalThreshold` starts at 0 and increases by deposit value).
- Structured events cover receives, allocations, claims, and ETH retrieval from StakePad.

### Proxy pattern

RewardReceiver clones are **EIP-1167** (`Clones.clone`). The implementation address is fixed per clone; existing clones do not run new bytecode. StakePad is the UUPS proxy. `updateRewardReceiverImpl` only affects clones created after the update.

### Storage

Claim balances and later fields are **appended after `_withdrawalThreshold`**, matching v1 slot order through that field. `_validatorPrincipals` and the pending-threshold flag are also appended. This does not shift `validators` / `_client` on a hypothetical future beacon/repoint of an old clone.

### Follow-up accounting

- **`removeValidator`** subtracts that validator's principal, then floors the threshold at already-received principal. Missing principal entries (old clones if they ever ran new code) are treated as 0 instead of reverting.
- **`percentageWithdraw`** is capped at unaccounted rewards, so it cannot take client principal. Payouts are recorded as `totalClaimedProvider` and `_feeAccountedRewards`.
- The 1-arg `addValidator(pubkey)` overload is removed; principal must be passed explicitly.
- A zero withdrawal threshold can be proposed and accepted (`INIT_WITHDRAWAL_THRESHOLD` is 0). Pending threshold uses an explicit flag so 0 is distinguishable from "nothing pending".

## Test plan

- [ ] `forge test`
- [ ] Confirm `removeValidator` after add-with-principal lowers the threshold, and remove after a claimed unstake does not drop it below accounted principal
- [ ] Confirm `percentageWithdraw` cannot take principal when threshold is 32 ETH and 32.2 ETH is on the contract
- [ ] Confirm owner can claim client/provider balances and accept pending commission/threshold
- [ ] New RewardReceiver implementation is required for clone-side changes; `updateRewardReceiverImpl` only affects clones created after the update