### PR TITLE
Fix multi-validator RewardReceiver bookkeeping

### DIFF
--- a/src/RewardReceiver.sol
+++ b/src/RewardReceiver.sol
@@ -99,16 +99,21 @@ contract RewardReceiver is IRewardReceiver, Initializable, OwnableUpgradeable, R
         uint256 totalReceived = _lifetimeReceived();
         uint256 totalRewards = totalReceived > _withdrawalThreshold ? totalReceived - _withdrawalThreshold : 0;
         uint256 grossRewards = totalRewards > _feeAccountedRewards ? totalRewards - _feeAccountedRewards : 0;
+
+        // Lowering the threshold can reclassify already-paid principal as rewards.
+        // That gap is not in the contract; book it without taking commission.
+        if (grossRewards > availableBalance) {
+            _feeAccountedRewards += grossRewards - availableBalance;
+            grossRewards = availableBalance;
+        }
+
         uint256 weightedCommission = (grossRewards * _commission) / BASIS_PTS;
-
-        require(weightedCommission <= availableBalance, "RewardReceiver: invalid accounting");
-
         uint256 clientAmount = availableBalance - weightedCommission;
         uint256 principalAmount = availableBalance > grossRewards ? availableBalance - grossRewards : 0;
 
         claimableClient += clientAmount;
         claimableProvider += weightedCommission;
-        _feeAccountedRewards = totalRewards;
+        _feeAccountedRewards += grossRewards;
 
         emit WithdrawalAllocated(
             _client, _provider, principalAmount, grossRewards, weightedCommission, clientAmount, weightedCommission
@@ -234,7 +239,9 @@ contract RewardReceiver is IRewardReceiver, Initializable, OwnableUpgradeable, R
             validators[index] = validators[len - 1];
         }
         validators.pop();
-        _decreaseProtectedPrincipal(removedPrincipal);
+        // Never lower the threshold: on-chain we cannot tell whether the
+        // removed validator's principal has already been received. A mistaken
+        // pubkey is corrected via propose/accept withdrawal threshold.
         emit ValidatorRemoved(index, removedValidator, removedPrincipal, _withdrawalThreshold);
     }
 
@@ -250,13 +257,13 @@ contract RewardReceiver is IRewardReceiver, Initializable, OwnableUpgradeable, R
         uint256 unaccountedRewards = _unaccountedRewards();
         uint256 availableBalance = _unallocatedBalance();
         uint256 withdrawable = unaccountedRewards < availableBalance ? unaccountedRewards : availableBalance;
-        uint256 amounToWithdraw = (withdrawable * percentage) / BASIS_PTS;
-        require(amounToWithdraw > 0, "RewardReceiver: amount too low");
-        totalClaimedProvider += amounToWithdraw;
-        _feeAccountedRewards += amounToWithdraw;
-        (bool success,) = address(_provider).call{value: amounToWithdraw}("");
+        uint256 amountToWithdraw = (withdrawable * percentage) / BASIS_PTS;
+        require(amountToWithdraw > 0, "RewardReceiver: amount too low");
+        totalClaimedProvider += amountToWithdraw;
+        _feeAccountedRewards += amountToWithdraw;
+        (bool success,) = address(_provider).call{value: amountToWithdraw}("");
         require(success, "RewardReceiver: transfer failed");
-        emit PercentageWithdrawn(_msgSender(), _provider, percentage, amounToWithdraw);
+        emit PercentageWithdrawn(_msgSender(), _provider, percentage, amountToWithdraw);
     }
 
     function getValidators() external view returns (bytes[] memory) {
@@ -336,22 +343,6 @@ contract RewardReceiver is IRewardReceiver, Initializable, OwnableUpgradeable, R
         uint256 totalReceived = _lifetimeReceived();
         uint256 totalRewards = totalReceived > _withdrawalThreshold ? totalReceived - _withdrawalThreshold : 0;
         return totalRewards > _feeAccountedRewards ? totalRewards - _feeAccountedRewards : 0;
-    }
-
-    function _decreaseProtectedPrincipal(uint256 protectedPrincipal) internal {
-        if (protectedPrincipal == 0) {
-            return;
-        }
-        if (protectedPrincipal >= _withdrawalThreshold) {
-            _withdrawalThreshold = 0;
-        } else {
-            _withdrawalThreshold -= protectedPrincipal;
-        }
-        uint256 received = _lifetimeReceived();
-        uint256 accountedPrincipal = received > _feeAccountedRewards ? received - _feeAccountedRewards : 0;
-        if (_withdrawalThreshold < accountedPrincipal) {
-            _withdrawalThreshold = accountedPrincipal;
-        }
     }
 
     function _checkValidPercentange(uint96 newPercentage) internal pure {

--- a/test/RewardReceiver.t.sol
+++ b/test/RewardReceiver.t.sol
@@ -792,8 +792,8 @@ contract RewardReceiverTest is TestUtils {
         vm.prank(testStakePad);
         rewardReceiver.removeValidator(1);
         require(
-            rewardReceiver.withdrawalThreshold() == 0,
-            "protected principal not released on remove"
+            rewardReceiver.withdrawalThreshold() == 32 ether,
+            "removeValidator must not lower the threshold"
         );
         require(
             rewardReceiver.getValidators().length == 1,
@@ -879,6 +879,101 @@ contract RewardReceiverTest is TestUtils {
         require(
             rewardReceiver.withdrawalThreshold() == 32 ether,
             "remove after unstake must not unprotect already-received principal"
+        );
+    }
+
+    function _receiveAndAllocate(uint256 amount) internal {
+        vm.deal(
+            address(rewardReceiver),
+            address(rewardReceiver).balance + amount
+        );
+        vm.prank(owner);
+        rewardReceiver.withdraw();
+        vm.prank(client);
+        rewardReceiver.claimClient();
+        if (rewardReceiver.claimableProvider() > 0) {
+            vm.prank(provider);
+            rewardReceiver.claimProvider();
+        }
+    }
+
+    function testRemoveExitedValidatorDoesNotUnprotectActivePrincipal() public {
+        vm.startPrank(testStakePad);
+        rewardReceiver.addValidator("A", 32 ether);
+        rewardReceiver.addValidator("B", 32 ether);
+        vm.stopPrank();
+
+        _receiveAndAllocate(32.4 ether);
+        vm.prank(testStakePad);
+        rewardReceiver.removeValidator(0);
+        require(
+            rewardReceiver.withdrawalThreshold() == 64 ether,
+            "remove must keep remaining beacon principal protected"
+        );
+
+        _receiveAndAllocate(32.3 ether);
+        require(
+            rewardReceiver.totalClaimedProvider() == 0.07 ether,
+            "commission must be 10% of 0.7 ETH rewards"
+        );
+        require(
+            rewardReceiver.totalClaimedClient() == 64.63 ether,
+            "client must receive remaining principal plus 90% of rewards"
+        );
+    }
+
+    function testAddValidatorDoesNotResetFeeAccountedRewards() public {
+        vm.prank(testStakePad);
+        rewardReceiver.addValidator("A", 32 ether);
+        _receiveAndAllocate(32.4 ether);
+        require(
+            rewardReceiver.feeAccountedRewards() == 0.4 ether,
+            "first cycle should account 0.4 ETH rewards"
+        );
+
+        vm.prank(testStakePad);
+        rewardReceiver.addValidator("B", 32 ether);
+        _receiveAndAllocate(0.1 ether);
+        require(
+            rewardReceiver.feeAccountedRewards() == 0.4 ether,
+            "feeAccountedRewards must be monotone"
+        );
+
+        _receiveAndAllocate(32.2 ether);
+        require(
+            rewardReceiver.totalClaimedProvider() == 0.07 ether,
+            "must not re-commission already accounted rewards"
+        );
+        require(
+            rewardReceiver.totalClaimedClient() == 64.63 ether,
+            "client total incorrect"
+        );
+    }
+
+    function testLoweredThresholdAfterPrincipalPaidDoesNotBrickWithdraw() public {
+        vm.prank(testStakePad);
+        rewardReceiver.addValidator("A", 32 ether);
+        _receiveAndAllocate(32.4 ether);
+
+        vm.startPrank(owner);
+        rewardReceiver.proposeNewWithdrawalThreshold(16 ether);
+        rewardReceiver.acceptNewWithdrawalThreshold();
+        vm.stopPrank();
+
+        vm.deal(
+            address(rewardReceiver),
+            address(rewardReceiver).balance + 0.1 ether
+        );
+        vm.prank(owner);
+        rewardReceiver.withdraw();
+
+        require(
+            rewardReceiver.claimableProvider() == 0.01 ether,
+            "commission only on newly available balance"
+        );
+        require(
+            rewardReceiver.claimableClient() == 0.09 ether,
+            "client keeps the rest of the new inflow"
         );
     }
 


### PR DESCRIPTION
## Summary
- Keep the withdrawal threshold unchanged on `removeValidator`, so remaining validators' principal stays protected after a partial exit.
- Make `_feeAccountedRewards` monotone (`+= grossRewards`) so adding a validator cannot wipe already-commissioned rewards.
- If the threshold is later lowered, `withdraw()` books already-paid principal without charging commission on it, instead of reverting with `invalid accounting`.

Addresses the three accounting defects from the PR 5 review. Owner-can-accept/claim remains a product decision for Wyatt and client docs, not a Solidity change.

## Test plan
- [ ] `forge test`
- [ ] Two-validator path: fund A+B, A exits, claim, `removeValidator(0)`, B exits — provider commission is 0.07 ETH, not ~3.23
- [ ] Add a second validator after rewards were accounted — `feeAccountedRewards` does not drop
- [ ] Lower threshold after principal was paid, then send 0.1 ETH — `withdraw()` succeeds
